### PR TITLE
Add `psgmrunner.cmakePath` setting and Windows CMake discovery; add VSIX packaging workflow

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -1,0 +1,45 @@
+name: Build VSIX
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build-vsix.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
+      - 'resources/**'
+      - 'README.md'
+      - 'LICENSE*'
+      - 'tsconfig.json'
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile extension
+        run: npm run compile
+
+      - name: Package VSIX
+        run: npm run package:vsix
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: psgmrunner-vsix
+          path: "*.vsix"
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The extension exposes these settings in VS Code `settings.json`:
 
 | Setting | Default | Description |
 | --- | --- | --- |
+| `psgmrunner.cmakePath` | `""` | Optional path to `cmake` executable for preset discovery. Useful when CMake is bundled with Visual Studio but not on `PATH`. |
 | `psgmrunner.tasks.presetConfigureCommandTemplate` | `cmake --preset ${preset} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` | Configure command template used for preset builds |
 | `psgmrunner.tasks.buildCommandTemplate` | `cmake --build ${buildDir}${configurationArgument} --target ${target}` | Build command template used for targets |
 | `psgmrunner.tasks.runCommandTemplate` | `${executableCommand}` | Run command template used for targets |
@@ -163,6 +164,7 @@ The extension exposes these settings in VS Code `settings.json`:
 
 ```json
 {
+  "psgmrunner.cmakePath": "C:/Program Files/Microsoft Visual Studio/2022/Professional/Common7/IDE/CommonExtensions/Microsoft/CMake/CMake/bin/cmake.exe",
   "psgmrunner.tasks.presetConfigureCommandTemplate": "cmake --preset ${preset} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
   "psgmrunner.tasks.buildCommandTemplate": "cmake --build ${buildDir}${configurationArgument} --target ${target}",
   "psgmrunner.tasks.runCommandTemplate": "${executableCommand}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "psgmrunner",
-    "version": "0.0.4",
+  "version": "0.0.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "psgmrunner",
-            "version": "0.0.4",
+      "version": "0.0.6",
             "license": "MIT",
             "devDependencies": {
                 "@types/mocha": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "psgmrunner",
     "displayName": "psgmrunner",
     "description": "Preset, target, build, run, and debug workflow for CMake-based C++ projects.",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "publisher": "local",
     "license": "MIT",
     "engines": {
@@ -137,6 +137,11 @@
                     "type": "string",
                     "default": "cmake --build ${buildDir}${configurationArgument} --target ${target}",
                     "description": "Build command template. Supports ${buildDir}, ${preset}, ${target}, ${sourceDir}, ${buildPreset}, ${configuration}, ${configurationArgument}, ${buildPresetArgument}, ${executablePath}, ${quotedExecutablePath}, and ${executableCommand}."
+                },
+                "psgmrunner.cmakePath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Optional path to cmake executable used for preset discovery (for example a Visual Studio bundled CMake path). Leave empty to use automatic detection."
                 },
                 "psgmrunner.tasks.presetConfigureCommandTemplate": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,11 @@
                     "default": "cmake --build ${buildDir}${configurationArgument} --target ${target}",
                     "description": "Build command template. Supports ${buildDir}, ${preset}, ${target}, ${sourceDir}, ${buildPreset}, ${configuration}, ${configurationArgument}, ${buildPresetArgument}, ${executablePath}, ${quotedExecutablePath}, and ${executableCommand}."
                 },
+                "psgmrunner.cmakePath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Optional path to cmake executable used for preset discovery (for example a Visual Studio bundled CMake path). Leave empty to use automatic detection."
+                },
                 "psgmrunner.tasks.presetConfigureCommandTemplate": {
                     "type": "string",
                     "default": "cmake --preset ${preset} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON",

--- a/src/services/presetProvider.ts
+++ b/src/services/presetProvider.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'child_process';
+import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
 import * as vscode from 'vscode';
@@ -38,6 +39,8 @@ interface ListedPreset {
 }
 
 export class PresetProvider {
+  private resolvedCMakeExecutable: string | undefined;
+
   public constructor(
     private readonly workspaceRoot: string,
     private readonly logger: OutputLogger,
@@ -178,8 +181,10 @@ export class PresetProvider {
   }
 
   private async listPresetsFromCMake(type: 'configure' | 'build'): Promise<ListedPreset[]> {
+    const cmakeExecutable = await this.resolveCMakeExecutable();
+
     try {
-      const { stdout } = await execFileAsync('cmake', ['-S', this.workspaceRoot, `--list-presets=${type}`], {
+      const { stdout } = await execFileAsync(cmakeExecutable, ['-S', this.workspaceRoot, `--list-presets=${type}`], {
         cwd: this.workspaceRoot,
         windowsHide: true,
       });
@@ -199,8 +204,89 @@ export class PresetProvider {
 
       return presets;
     } catch (error) {
-      this.logger.warn(`Unable to query ${type} presets from CMake: ${error instanceof Error ? error.message : String(error)}`);
+      this.logger.warn(
+        `Unable to query ${type} presets from CMake (${cmakeExecutable}): ${error instanceof Error ? error.message : String(error)}`,
+      );
       return [];
+    }
+  }
+
+  private async resolveCMakeExecutable(): Promise<string> {
+    if (this.resolvedCMakeExecutable) {
+      return this.resolvedCMakeExecutable;
+    }
+
+    const configuredPath = vscode.workspace.getConfiguration('psgmrunner').get<string>('cmakePath', '').trim();
+    if (configuredPath) {
+      if (path.isAbsolute(configuredPath) && !fs.existsSync(configuredPath)) {
+        this.logger.warn(`Configured psgmrunner.cmakePath does not exist: ${configuredPath}`);
+      } else {
+        this.resolvedCMakeExecutable = configuredPath;
+        return configuredPath;
+      }
+    }
+
+    if (process.platform === 'win32') {
+      const fromWhere = await this.findCMakeFromWhere();
+      if (fromWhere) {
+        this.resolvedCMakeExecutable = fromWhere;
+        return fromWhere;
+      }
+
+      const fromVsWhere = await this.findCMakeFromVsWhere();
+      if (fromVsWhere) {
+        this.resolvedCMakeExecutable = fromVsWhere;
+        return fromVsWhere;
+      }
+    }
+
+    this.resolvedCMakeExecutable = 'cmake';
+    return this.resolvedCMakeExecutable;
+  }
+
+  private async findCMakeFromWhere(): Promise<string | undefined> {
+    try {
+      const { stdout } = await execFileAsync('where.exe', ['cmake'], { windowsHide: true });
+      const firstMatch = stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => line.length > 0);
+      return firstMatch;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async findCMakeFromVsWhere(): Promise<string | undefined> {
+    const programFilesX86 = process.env['ProgramFiles(x86)'] ?? process.env.ProgramFiles;
+    if (!programFilesX86) {
+      return undefined;
+    }
+
+    const vswherePath = path.join(programFilesX86, 'Microsoft Visual Studio', 'Installer', 'vswhere.exe');
+    if (!fs.existsSync(vswherePath)) {
+      return undefined;
+    }
+
+    try {
+      const { stdout } = await execFileAsync(vswherePath, [
+        '-latest',
+        '-products',
+        '*',
+        '-requires',
+        'Microsoft.VisualStudio.Component.VC.CMake.Project',
+        '-find',
+        'Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\CMake\\bin\\cmake.exe',
+      ], {
+        windowsHide: true,
+      });
+      const firstMatch = stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => line.length > 0);
+      return firstMatch;
+    } catch {
+      return undefined;
     }
   }
 


### PR DESCRIPTION
### Motivation

- Provide a way to explicitly point the extension at a `cmake` executable (useful for Visual Studio-bundled CMake not on `PATH`).
- Improve preset discovery on Windows by trying `where.exe` and `vswhere.exe` before falling back to `cmake`.
- Add a GitHub Actions workflow to build and upload a VSIX artifact for releases.

### Description

- Added a new configuration `psgmrunner.cmakePath` to `package.json` and documented it in `README.md` to allow specifying an absolute `cmake` path.
- Implemented `resolveCMakeExecutable()` in `src/services/presetProvider.ts` to prefer the configured path and then try `where.exe` and `vswhere.exe` on Windows before defaulting to `cmake`, and used the resolved executable when calling `execFile` for `--list-presets`; updated logging to include the executable path and added `fs` import and a cached `resolvedCMakeExecutable` field.
- Added `build-vsix.yml` GitHub Actions workflow to compile the extension, run `npm run package:vsix`, and upload the resulting `.vsix` as an artifact.
- Bumped package version in `package.json` and `package-lock.json` to `0.0.6`.

### Testing

- No automated tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d6097454832487c60a9c3cb906f8)