### PR TITLE
Avoid revealing active source when target tree is hidden, update mock, and bump version to 0.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "psgmrunner",
-  "version": "0.0.6",
+    "version": "0.0.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "psgmrunner",
-      "version": "0.0.6",
+            "version": "0.0.8",
             "license": "MIT",
             "devDependencies": {
                 "@types/mocha": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "psgmrunner",
     "displayName": "psgmrunner",
     "description": "Preset, target, build, run, and debug workflow for CMake-based C++ projects.",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "publisher": "local",
     "license": "MIT",
     "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -256,11 +256,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   };
 
   const revealActiveSource = async (filePath: string | undefined): Promise<void> => {
-    if (!filePath) {
+    targetTreeDataProvider.setActiveSourcePath(filePath);
+
+    if (!filePath || !targetsTreeView.visible) {
       return;
     }
 
-    targetTreeDataProvider.setActiveSourcePath(filePath);
     const sourceItem = targetTreeDataProvider.findFirstSourceItemByFile(filePath);
     if (!sourceItem) {
       logger.info(`Active file is not present in target tree: ${filePath}`);
@@ -269,9 +270,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     try {
       await targetsTreeView.reveal(sourceItem, {
-        select: true,
+        select: false,
         focus: false,
-        expand: true,
+        expand: false,
       });
     } catch (error) {
       logger.warn(`Unable to reveal active source ${filePath}: ${error instanceof Error ? error.message : String(error)}`);

--- a/test/vscode-mock.js
+++ b/test/vscode-mock.js
@@ -66,6 +66,7 @@ const vscode = {
         options,
         description: undefined,
         message: undefined,
+        visible: true,
         reveal: async () => undefined,
         dispose: () => { createdTreeViews.delete(id); },
       };


### PR DESCRIPTION
### Motivation

- Prevent attempts to reveal an active source in the targets tree when the tree view is not visible, which could throw or cause unwanted focus/expansion.  
- Ensure tests accurately reflect a visible tree view and publish a new patch release.

### Description

- Callled `targetTreeDataProvider.setActiveSourcePath` before early-return so the active source is tracked even when not revealed.  
- Added a guard to return early when `!filePath || !targetsTreeView.visible` to avoid revealing when the tree is hidden.  
- Changed `targetsTreeView.reveal` options to `select: false` and `expand: false` to avoid automatically selecting or expanding items.  
- Updated the test mock `createTreeView` to include `visible: true` so unit tests simulate a visible view.  
- Bumped package versions to `0.0.8` in `package.json` and `package-lock.json`.

### Testing

- Ran `npm run test` (compiles and runs unit tests via `test/run-unit.js`) and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72efba5c48324848b729344905fb0)