### PR TITLE
Safer preset cleanup: remove CMake configure artifacts and bump version to 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cmakerunner",
-    "version": "0.0.8",
+    "version": "0.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cmakerunner",
-            "version": "0.0.8",
+            "version": "0.1.3",
             "license": "MIT",
             "devDependencies": {
                 "@types/mocha": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cmakerunner",
     "displayName": "CMake Runner",
     "description": "Preset, target, build, run, and debug workflow for CMake-based C++ projects.",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "publisher": "Simon-tools",
     "repository": {
         "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,12 +143,40 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
 
     try {
-      logger.info(`Cleaning build directory for preset ${preset.name}: ${preset.binaryDir}`);
-      await vscode.workspace.fs.delete(buildDirectoryUri, { recursive: true, useTrash: false });
+      const cmakeCleanupTargets = [
+        '.cmake',
+        'CMakeCache.txt',
+        'CMakeFiles',
+      ];
+
+      const cleanedPaths: string[] = [];
+
+      for (const targetName of cmakeCleanupTargets) {
+        const targetUri = vscode.Uri.file(path.join(preset.binaryDir, targetName));
+
+        try {
+          await vscode.workspace.fs.stat(targetUri);
+        } catch (error) {
+          const code = (error as vscode.FileSystemError | undefined)?.code;
+          if (code === 'FileNotFound') {
+            continue;
+          }
+
+          throw error;
+        }
+
+        await vscode.workspace.fs.delete(targetUri, { recursive: true, useTrash: false });
+        cleanedPaths.push(targetUri.fsPath);
+      }
+
+      logger.info(
+        `Cleaning CMake configure artifacts for preset ${preset.name}: ${cleanedPaths.length > 0 ? cleanedPaths.join(', ') : 'no known configure artifacts found'}`,
+      );
+
       return true;
     } catch (error) {
-      logger.warn(`Unable to clean build directory ${preset.binaryDir}: ${error instanceof Error ? error.message : String(error)}`);
-      void vscode.window.showErrorMessage(`Unable to clean build directory for preset ${preset.displayName}.`);
+      logger.warn(`Unable to clean CMake configure artifacts in ${preset.binaryDir}: ${error instanceof Error ? error.message : String(error)}`);
+      void vscode.window.showErrorMessage(`Unable to clean CMake configure artifacts for preset ${preset.displayName}.`);
       return false;
     }
   };


### PR DESCRIPTION
### Motivation
- Prevent destructive removal of an entire build directory when clearing a preset by targeting known CMake configure artifacts instead. 
- Improve robustness and logging when cleanup targets do not exist or cannot be inspected. 
- Publish a patch release version bump to `0.1.3`.

### Description
- Replace full-directory deletion in `clearPresetBuildDirectory` with selective deletion of known configure artifacts (`.cmake`, `CMakeCache.txt`, `CMakeFiles`) in the preset `binaryDir` and collect cleaned paths for logging. 
- Add existence checks per-target and skip missing items while surfacing unexpected errors, and update log and user-visible error messages accordingly. 
- Update package metadata versions in `package.json` and `package-lock.json` from `0.1.2`/`0.0.8` to `0.1.3`.

### Testing
- TypeScript build was run via `npm run compile` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01b44aab48324a7b4110d5d8b4f73)