### PR TITLE
Hide missing executables in GTests view

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ Use `Clear Filter` to remove the current filter.
 ### 7. Run one GoogleTest case
 
 Use the **GTests** view next to **Targets** to inspect GoogleTest cases by executable target.
-Expanding a target runs it with `--gtest_list_tests`. Selecting a discovered case runs the same
-target with `--gtest_filter=<suite.case>`.
+Only targets whose executable already exists on disk are shown. Expanding a target runs it with
+`--gtest_list_tests`. Selecting a discovered case runs the same target with `--gtest_filter=<suite.case>`.
 Use `Filter` to match target names, executable names, suite names, case names, or full
-`suite.case` filters. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached discovery results.
+`suite.case` filters. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached
+discovery results and re-check which executables have been generated.
 
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Use `Clear Filter` to remove the current filter.
 Use the **GTests** view next to **Targets** to inspect GoogleTest cases by executable target.
 Only targets whose executable already exists on disk are shown. Expanding a target runs it with
 `--gtest_list_tests`. Selecting a discovered case runs the same target with `--gtest_filter=<suite.case>`.
-Use `Filter` to match target names, executable names, suite names, case names, or full
-`suite.case` filters. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached
+Use `Filter` to pick from discovered targets and test cases, or type a manual filter matching target names,
+executable names, suite names, case names, or full `suite.case` filters. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached
 discovery results and re-check which executables have been generated.
 
 

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -108,8 +108,8 @@ code --install-extension cmakerunner-0.x.x.vsix
 你可以在和 **Targets** 并列的 **GTests** 视图中按可执行目标查看 GoogleTest 用例。
 这里仅显示已经在磁盘上生成 executable 的目标。展开某个目标时会执行 `--gtest_list_tests` 读取用例；点击单个用例后，会用
 `--gtest_filter=<suite.case>` 只运行该用例。
-使用 `Filter` 可以按目标名、可执行文件名、suite 名、case 名或完整
-`suite.case` 过滤；使用 `Clear Filter` 清除过滤；使用 `Refresh`
+使用 `Filter` 可以从已发现的目标和用例中选择，也可以手动输入目标名、可执行文件名、
+suite 名、case 名或完整 `suite.case` 过滤；使用 `Clear Filter` 清除过滤；使用 `Refresh`
 清除已缓存的用例发现结果，并重新检查哪些 executable 已经生成。
 
 ### 7. 过滤目标

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -106,11 +106,11 @@ code --install-extension cmakerunner-0.x.x.vsix
 ### 6. 运行单个 GoogleTest 用例
 
 你可以在和 **Targets** 并列的 **GTests** 视图中按可执行目标查看 GoogleTest 用例。
-展开某个目标时会执行 `--gtest_list_tests` 读取用例；点击单个用例后，会用
+这里仅显示已经在磁盘上生成 executable 的目标。展开某个目标时会执行 `--gtest_list_tests` 读取用例；点击单个用例后，会用
 `--gtest_filter=<suite.case>` 只运行该用例。
 使用 `Filter` 可以按目标名、可执行文件名、suite 名、case 名或完整
 `suite.case` 过滤；使用 `Clear Filter` 清除过滤；使用 `Refresh`
-清除已缓存的用例发现结果。
+清除已缓存的用例发现结果，并重新检查哪些 executable 已经生成。
 
 ### 7. 过滤目标
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,11 @@ interface TargetQuickPickItem extends vscode.QuickPickItem {
   readonly action?: 'customTextFilter';
 }
 
+interface GTestQuickPickItem extends vscode.QuickPickItem {
+  readonly filterText?: string;
+  readonly action?: 'manualFilter';
+}
+
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
   if (!workspaceFolder) {
@@ -370,16 +375,48 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       await updateGTestViewState();
     }),
     vscode.commands.registerCommand('cmakerunner.filterGTests', async () => {
-      const filterText = await vscode.window.showInputBox({
-        prompt: 'Filter GoogleTest targets or cases',
-        placeHolder: 'Example: gtest, MathTest, Adds, MathTest.Adds',
-        value: gtestTreeDataProvider.getFilterText(),
-      });
-      if (filterText === undefined) {
+      const filterItems = await gtestTreeDataProvider.getFilterItems();
+      const pick = await vscode.window.showQuickPick<GTestQuickPickItem>(
+        [
+          ...filterItems.map((item) => ({
+            label: item.type === 'case' ? item.label : item.label,
+            description: item.description,
+            detail: item.detail,
+            filterText: item.filterText,
+          })),
+          {
+            label: '$(edit) Manual filter...',
+            description: 'Type a custom GoogleTest filter',
+            detail: 'Example: gtest, MathTest, Adds, MathTest.Adds',
+            action: 'manualFilter' as const,
+          },
+        ],
+        {
+          prompt: 'Filter GoogleTest targets or cases',
+          placeHolder: 'Select a target or test case',
+          matchOnDescription: true,
+          matchOnDetail: true,
+        },
+      );
+      if (!pick) {
         return;
       }
 
-      await applyGTestFilter(filterText);
+      if (pick.action === 'manualFilter') {
+        const filterText = await vscode.window.showInputBox({
+          prompt: 'Filter GoogleTest targets or cases',
+          placeHolder: 'Example: gtest, MathTest, Adds, MathTest.Adds',
+          value: gtestTreeDataProvider.getFilterText(),
+        });
+        if (filterText === undefined) {
+          return;
+        }
+
+        await applyGTestFilter(filterText);
+        return;
+      }
+
+      await applyGTestFilter(pick.filterText ?? pick.label);
     }),
     vscode.commands.registerCommand('cmakerunner.clearGTestFilter', async () => {
       await applyGTestFilter('');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,6 +71,27 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     await updateTargetViewState();
   };
 
+  const getGeneratedExecutableTargets = async (targets: TargetInfo[]): Promise<TargetInfo[]> => {
+    const generatedTargets: TargetInfo[] = [];
+
+    for (const target of targets) {
+      try {
+        const stat = await vscode.workspace.fs.stat(vscode.Uri.file(target.guessedExecutablePath));
+        if (stat.type === vscode.FileType.File || stat.type === vscode.FileType.SymbolicLink) {
+          generatedTargets.push(target);
+        }
+      } catch (error) {
+        logger.info(`Skipping GoogleTest target ${target.name} because executable does not exist: ${target.guessedExecutablePath}`);
+      }
+    }
+
+    return generatedTargets;
+  };
+
+  const updateGTestTargets = async (targets: TargetInfo[]): Promise<void> => {
+    gtestTreeDataProvider.setTargets(await getGeneratedExecutableTargets(targets));
+  };
+
   const updateGTestViewState = async (): Promise<void> => {
     const filterText = gtestTreeDataProvider.getFilterText();
     gtestsTreeView.description = filterText ? `Filter: ${filterText}` : undefined;
@@ -114,7 +135,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       const targets = mappingEngine.getTargets();
     //   logger.info(`Resolved ${targets.length} mapped target(s) for preset ${currentPreset.name}`);
       targetTreeDataProvider.setTargets(targets, currentPreset.sourceDir, activeFile);
-      gtestTreeDataProvider.setTargets(targets);
+      await updateGTestTargets(targets);
       await updateTargetViewState();
       await updateGTestViewState();
     //   await revealActiveSource(activeFile);
@@ -123,7 +144,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     logger.warn('Skipping target update because no preset is selected');
     targetTreeDataProvider.setTargets([], workspaceRoot, activeFile);
-    gtestTreeDataProvider.setTargets([]);
+    await updateGTestTargets([]);
     await updateTargetViewState();
     await updateGTestViewState();
   };
@@ -345,6 +366,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand('cmakerunner.refreshGTests', async () => {
       gtestTreeDataProvider.refresh();
+      await updateGTestTargets(mappingEngine.getTargets());
       await updateGTestViewState();
     }),
     vscode.commands.registerCommand('cmakerunner.filterGTests', async () => {
@@ -449,6 +471,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       await workflowManager.buildTarget(preset, target);
+      await updateGTestTargets(mappingEngine.getTargets());
+      await updateGTestViewState();
     }),
     vscode.commands.registerCommand('cmakerunner.buildTargetFromCurrentFile', async () => {
       const preset = ensurePreset();
@@ -467,6 +491,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       await workflowManager.buildTarget(preset, pick.target);
+      await updateGTestTargets(mappingEngine.getTargets());
+      await updateGTestViewState();
     }),
     vscode.commands.registerCommand('cmakerunner.runTarget', async (item?: TargetTreeItem | SourceTreeItem) => {
       const preset = ensurePreset();

--- a/src/services/workflowManager.ts
+++ b/src/services/workflowManager.ts
@@ -213,11 +213,23 @@ export class WorkflowManager {
 
   public async listGTestCases(preset: PresetInfo, target: TargetInfo): Promise<GTestCaseInfo[] | undefined> {
     try {
+      const executableStat = await vscode.workspace.fs.stat(vscode.Uri.file(target.guessedExecutablePath));
+      if (executableStat.type !== vscode.FileType.File && executableStat.type !== vscode.FileType.SymbolicLink) {
+        this.logger.info(`Skipping GoogleTest discovery for ${target.name} because executable is not a file: ${target.guessedExecutablePath}`);
+        return [];
+      }
+
       const output = await execFileText(target.guessedExecutablePath, ['--gtest_list_tests'], preset.binaryDir);
       const testCases = parseGTestListOutput(output);
       this.logger.info(`Discovered ${testCases.length} GoogleTest case(s) in ${target.name}`);
       return testCases;
     } catch (error) {
+      const code = (error as vscode.FileSystemError | NodeJS.ErrnoException | undefined)?.code;
+      if (code === 'FileNotFound' || code === 'ENOENT') {
+        this.logger.info(`Skipping GoogleTest discovery for ${target.name} because executable does not exist: ${target.guessedExecutablePath}`);
+        return [];
+      }
+
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(`Unable to list GoogleTest cases for ${target.name}: ${message}`);
       void vscode.window.showErrorMessage(`Unable to list GoogleTest cases for ${target.displayName}. ${message}`);

--- a/src/ui/gtestTreeDataProvider.ts
+++ b/src/ui/gtestTreeDataProvider.ts
@@ -33,6 +33,14 @@ export class GTestCaseTreeItem extends vscode.TreeItem {
 
 type Node = GTestTargetTreeItem | GTestCaseTreeItem;
 
+export interface GTestFilterItem {
+  readonly type: 'target' | 'case';
+  readonly label: string;
+  readonly description?: string;
+  readonly detail?: string;
+  readonly filterText: string;
+}
+
 export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
   private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<Node | undefined | void>();
   private targets: TargetInfo[] = [];
@@ -69,6 +77,33 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
 
   public async getVisibleTargetCount(): Promise<number> {
     return (await this.getVisibleTargets()).length;
+  }
+
+  public async getFilterItems(): Promise<GTestFilterItem[]> {
+    const items: GTestFilterItem[] = [];
+
+    for (const target of this.targets) {
+      items.push({
+        type: 'target',
+        label: target.displayName,
+        description: path.basename(target.guessedExecutablePath),
+        detail: target.guessedExecutablePath,
+        filterText: target.displayName,
+      });
+
+      const testCases = await this.getTestCases(target);
+      for (const testCase of testCases) {
+        items.push({
+          type: 'case',
+          label: testCase.name,
+          description: `${testCase.suite} - ${target.displayName}`,
+          detail: testCase.filter,
+          filterText: testCase.filter,
+        });
+      }
+    }
+
+    return items;
   }
 
   public getTreeItem(element: Node): vscode.TreeItem {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -221,4 +221,27 @@ describe('extension commands', () => {
     await vscode.commands.executeCommand('cmakerunner.clearGTestFilter');
     assert.strictEqual(gtestsTreeView?.description, undefined);
   });
+
+  it('GTests view shows only targets whose executable exists', async () => {
+    const binDir = path.join(fixtureRoot, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'app'), '#!/bin/sh\nexit 0\n');
+    for (const missingExecutable of ['demo', 'helper']) {
+      try {
+        fs.unlinkSync(path.join(binDir, missingExecutable));
+      } catch {
+        // ignore
+      }
+    }
+
+    try {
+      await activateExtension();
+
+      const gtestsTreeView = mockedVscode.__mock.createdTreeViews.get('cmakerunner.gtests') as any;
+      const children = await gtestsTreeView.options.treeDataProvider.getChildren();
+      assert.deepStrictEqual(children.map((item: { label: string }) => item.label), ['app']);
+    } finally {
+      fs.unlinkSync(path.join(binDir, 'app'));
+    }
+  });
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -208,18 +208,49 @@ describe('extension commands', () => {
     assert.ok(mockedVscode.__mock.createdTreeViews.has('cmakerunner.gtests'));
   });
 
-  it('filterGTests applies and clears the gtest view filter', async () => {
+  it('filterGTests applies the selected gtest quick pick item and clears the filter', async () => {
+    const binDir = path.join(fixtureRoot, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'app'), '#!/bin/sh\nexit 0\n');
     await activateExtension();
 
+    const workflowModule = require('../src/services/workflowManager') as typeof import('../src/services/workflowManager');
+    const originalListGTestCases = workflowModule.WorkflowManager.prototype.listGTestCases;
+    workflowModule.WorkflowManager.prototype.listGTestCases = async () => [
+      { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+    ];
+    (vscode.window as any).showQuickPick = async (items: readonly { detail?: string }[]) => (
+      items as Array<{ detail?: string }>
+    ).find((item) => item.detail === 'MathTest.Adds');
+
+    try {
+      await vscode.commands.executeCommand('cmakerunner.filterGTests');
+
+      const gtestsTreeView = mockedVscode.__mock.createdTreeViews.get('cmakerunner.gtests');
+      assert.ok(gtestsTreeView);
+      assert.strictEqual(gtestsTreeView?.description, 'Filter: MathTest.Adds');
+
+      await vscode.commands.executeCommand('cmakerunner.clearGTestFilter');
+      assert.strictEqual(gtestsTreeView?.description, undefined);
+    } finally {
+      workflowModule.WorkflowManager.prototype.listGTestCases = originalListGTestCases;
+      fs.unlinkSync(path.join(binDir, 'app'));
+    }
+  });
+
+  it('filterGTests supports manual filter input', async () => {
+    await activateExtension();
+
+    (vscode.window as any).showQuickPick = async (items: readonly { action?: string }[]) => (
+      items as Array<{ action?: string }>
+    ).find((item) => item.action === 'manualFilter');
     (vscode.window as any).showInputBox = async () => 'MathTest';
+
     await vscode.commands.executeCommand('cmakerunner.filterGTests');
 
     const gtestsTreeView = mockedVscode.__mock.createdTreeViews.get('cmakerunner.gtests');
     assert.ok(gtestsTreeView);
     assert.strictEqual(gtestsTreeView?.description, 'Filter: MathTest');
-
-    await vscode.commands.executeCommand('cmakerunner.clearGTestFilter');
-    assert.strictEqual(gtestsTreeView?.description, undefined);
   });
 
   it('GTests view shows only targets whose executable exists', async () => {

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -451,6 +451,24 @@ describe('ui', () => {
       assert.strictEqual(await provider.getVisibleTargetCount(), 1);
     });
 
+    it('should expose gtest filter quick pick items for targets and cases', async () => {
+      const provider = new GTestTreeDataProvider(async () => [
+        { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+      ]);
+      provider.setTargets([target]);
+
+      const items = await provider.getFilterItems();
+
+      assert.deepStrictEqual(items.map((item) => ({
+        type: item.type,
+        label: item.label,
+        filterText: item.filterText,
+      })), [
+        { type: 'target', label: 'Tests', filterText: 'Tests' },
+        { type: 'case', label: 'Adds', filterText: 'MathTest.Adds' },
+      ]);
+    });
+
     it('should clear gtest filter text', () => {
       const provider = new GTestTreeDataProvider(async () => []);
       provider.setFilterText('math');

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -219,7 +219,9 @@ describe('workflow manager', () => {
     };
 
     const originalExecFile = childProcess.execFile;
+    const originalStat = vscode.workspace.fs.stat;
     const originalShowQuickPick = vscode.window.showQuickPick;
+    (vscode.workspace.fs as any).stat = async () => ({ type: vscode.FileType.File });
     (childProcess as any).execFile = (_file: string, _args: string[], _options: unknown, callback: Function) => {
       callback(undefined, 'SuiteA.\n  TestOne\n  TestTwo\n', '');
       return {} as ChildProcess;
@@ -231,8 +233,29 @@ describe('workflow manager', () => {
       await manager.runGTestCase(preset, target, false);
       assert.strictEqual(runCommand, '/tmp/build/debug/app --gtest_filter=SuiteA.TestTwo');
     } finally {
+      (vscode.workspace.fs as any).stat = originalStat;
       (childProcess as any).execFile = originalExecFile;
       (vscode.window as any).showQuickPick = originalShowQuickPick;
+    }
+  });
+
+  it('listGTestCases returns empty without showing an error when the executable is missing', async () => {
+    const deps = createDeps();
+    let shown = '';
+    const originalShowErrorMessage = vscode.window.showErrorMessage;
+    (vscode.window as any).showErrorMessage = async (message: string) => {
+      shown = message;
+      return undefined;
+    };
+
+    try {
+      const manager = new WorkflowManager(deps.configurationManager as never, deps.taskExecutionEngine as never, deps.logger as never);
+      const result = await manager.listGTestCases(preset, target);
+      assert.deepStrictEqual(result, []);
+      assert.strictEqual(shown, '');
+      assert.ok(deps.calls.some((call) => call.includes('executable does not exist')));
+    } finally {
+      (vscode.window as any).showErrorMessage = originalShowErrorMessage;
     }
   });
 


### PR DESCRIPTION
## Summary

- hide GTests targets whose executable has not been generated yet
- re-check generated executables when refreshing GTests and after target builds
- treat missing executable discovery as an empty result instead of showing an ENOENT error

Closes https://github.com/simonln/cmakerunner/issues/8

## Test

- `PATH="../.tools/bin:$PATH" npm test`
