### PR TITLE
Require explicit run action for GTest cases

### DIFF
--- a/README-ALL.md
+++ b/README-ALL.md
@@ -109,8 +109,8 @@ By default, both actions build the target first.
 ### 6. Run one GoogleTest case
 
 Use the **GTests** view next to **Targets** to inspect GoogleTest cases by executable target.
-Expanding a target runs it with `--gtest_list_tests`. Selecting a discovered case runs the same
-target with `--gtest_filter=<suite.case>`.
+Expanding a target runs it with `--gtest_list_tests`. Use the inline `Run` action beside a
+discovered case to run the same target with `--gtest_filter=<suite.case>`.
 Use `Filter` to match target names, executable names, suite names, case names, or full
 `suite.case` filters. Use `Clear Filter` to remove the filter, and `Refresh` to clear
 cached discovery results.

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Use `Clear Filter` to remove the current filter.
 ### 7. Run one GoogleTest case
 
 Use the **GTests** view next to **Targets** to inspect GoogleTest cases by executable target.
-Expanding a target runs it with `--gtest_list_tests`. Selecting a discovered case runs the same
-target with `--gtest_filter=<suite.case>`.
+Expanding a target runs it with `--gtest_list_tests`. Use the inline `Run` action beside a
+discovered case to run the same target with `--gtest_filter=<suite.case>`.
 Use `Filter` to match target names, executable names, suite names, case names, or full
 `suite.case` filters. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached discovery results.
 

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -106,8 +106,8 @@ code --install-extension cmakerunner-0.x.x.vsix
 ### 6. 运行单个 GoogleTest 用例
 
 你可以在和 **Targets** 并列的 **GTests** 视图中按可执行目标查看 GoogleTest 用例。
-展开某个目标时会执行 `--gtest_list_tests` 读取用例；点击单个用例后，会用
-`--gtest_filter=<suite.case>` 只运行该用例。
+展开某个目标时会执行 `--gtest_list_tests` 读取用例；通过单个用例右侧的
+`Run` 操作，会用 `--gtest_filter=<suite.case>` 只运行该用例。
 使用 `Filter` 可以按目标名、可执行文件名、suite 名、case 名或完整
 `suite.case` 过滤；使用 `Clear Filter` 清除过滤；使用 `Refresh`
 清除已缓存的用例发现结果。

--- a/src/ui/gtestTreeDataProvider.ts
+++ b/src/ui/gtestTreeDataProvider.ts
@@ -23,11 +23,6 @@ export class GTestCaseTreeItem extends vscode.TreeItem {
     this.tooltip = testCase.filter;
     this.contextValue = 'gtestCase';
     this.iconPath = new vscode.ThemeIcon('testing-passed-icon');
-    this.command = {
-      command: 'cmakerunner.runGTestCase',
-      title: 'Run GTest Case',
-      arguments: [this],
-    };
   }
 }
 

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -396,7 +396,7 @@ describe('ui', () => {
       assert.strictEqual(cases.length, 1);
       assert.ok(cases[0] instanceof GTestCaseTreeItem);
       assert.strictEqual(cases[0].contextValue, 'gtestCase');
-      assert.strictEqual(cases[0].command?.command, 'cmakerunner.runGTestCase');
+      assert.strictEqual(cases[0].command, undefined);
     });
 
     it('should cache discovered cases until refresh', async () => {


### PR DESCRIPTION
## Summary
- prevent GTests tree case selection from immediately running the test case
- keep the explicit inline/context Run action for GTest cases
- update README docs and unit coverage for the new selection behavior

Fixes #10

## Test
- `PATH="/Users/chenyi/Documents/New project/.tools/bin:$PATH" npm test`