### PR TITLE
Run filtered GTest cases from target action

### DIFF
--- a/README-ALL.md
+++ b/README-ALL.md
@@ -111,8 +111,9 @@ By default, both actions build the target first.
 Use the **GTests** view next to **Targets** to inspect GoogleTest cases by executable target.
 Expanding a target runs it with `--gtest_list_tests`. Use the inline `Run` action beside a
 discovered case to run the same target with `--gtest_filter=<suite.case>`.
-Use `Filter` to match target names, executable names, suite names, case names, or full
-`suite.case` filters. When a filter is active, the target-level `Run` action runs only the
+Use `Filter` to choose from the current target, discovered suites, or discovered cases. It matches
+target names, executable names, suite names, case names, or full `suite.case` filters.
+When a filter is active, the target-level `Run` action runs only the
 visible GoogleTest cases. Use `Clear Filter` to remove the filter, and `Refresh` to clear
 cached discovery results.
 

--- a/README-ALL.md
+++ b/README-ALL.md
@@ -112,7 +112,8 @@ Use the **GTests** view next to **Targets** to inspect GoogleTest cases by execu
 Expanding a target runs it with `--gtest_list_tests`. Use the inline `Run` action beside a
 discovered case to run the same target with `--gtest_filter=<suite.case>`.
 Use `Filter` to match target names, executable names, suite names, case names, or full
-`suite.case` filters. Use `Clear Filter` to remove the filter, and `Refresh` to clear
+`suite.case` filters. When a filter is active, the target-level `Run` action runs only the
+visible GoogleTest cases. Use `Clear Filter` to remove the filter, and `Refresh` to clear
 cached discovery results.
 
 ### 7. Filter targets

--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ Use `Clear Filter` to remove the current filter.
 Use the **GTests** view next to **Targets** to inspect GoogleTest cases by executable target.
 Expanding a target runs it with `--gtest_list_tests`. Use the inline `Run` action beside a
 discovered case to run the same target with `--gtest_filter=<suite.case>`.
-Use `Filter` to match target names, executable names, suite names, case names, or full
-`suite.case` filters. When a filter is active, the target-level `Run` action runs only the
+Use `Filter` to choose from the current target, discovered suites, or discovered cases. It matches
+target names, executable names, suite names, case names, or full `suite.case` filters.
+When a filter is active, the target-level `Run` action runs only the
 visible GoogleTest cases. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached discovery results.
 
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Use the **GTests** view next to **Targets** to inspect GoogleTest cases by execu
 Expanding a target runs it with `--gtest_list_tests`. Use the inline `Run` action beside a
 discovered case to run the same target with `--gtest_filter=<suite.case>`.
 Use `Filter` to match target names, executable names, suite names, case names, or full
-`suite.case` filters. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached discovery results.
+`suite.case` filters. When a filter is active, the target-level `Run` action runs only the
+visible GoogleTest cases. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached discovery results.
 
 
 ## Commands

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -109,8 +109,8 @@ code --install-extension cmakerunner-0.x.x.vsix
 展开某个目标时会执行 `--gtest_list_tests` 读取用例；通过单个用例右侧的
 `Run` 操作，会用 `--gtest_filter=<suite.case>` 只运行该用例。
 使用 `Filter` 可以按目标名、可执行文件名、suite 名、case 名或完整
-`suite.case` 过滤；使用 `Clear Filter` 清除过滤；使用 `Refresh`
-清除已缓存的用例发现结果。
+`suite.case` 过滤。过滤生效时，目标右侧的 `Run` 操作只会运行当前可见的
+GoogleTest 用例；使用 `Clear Filter` 清除过滤；使用 `Refresh` 清除已缓存的用例发现结果。
 
 ### 7. 过滤目标
 

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -108,9 +108,10 @@ code --install-extension cmakerunner-0.x.x.vsix
 你可以在和 **Targets** 并列的 **GTests** 视图中按可执行目标查看 GoogleTest 用例。
 展开某个目标时会执行 `--gtest_list_tests` 读取用例；通过单个用例右侧的
 `Run` 操作，会用 `--gtest_filter=<suite.case>` 只运行该用例。
-使用 `Filter` 可以按目标名、可执行文件名、suite 名、case 名或完整
-`suite.case` 过滤。过滤生效时，目标右侧的 `Run` 操作只会运行当前可见的
-GoogleTest 用例；使用 `Clear Filter` 清除过滤；使用 `Refresh` 清除已缓存的用例发现结果。
+使用 `Filter` 会展示当前目标、已发现的 suite 和已发现的 case，并可按目标名、
+可执行文件名、suite 名、case 名或完整 `suite.case` 过滤。过滤生效时，目标右侧的
+`Run` 操作只会运行当前可见的 GoogleTest 用例；使用 `Clear Filter` 清除过滤；使用 `Refresh`
+清除已缓存的用例发现结果。
 
 ### 7. 过滤目标
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { PresetInfo, TargetInfo } from './models';
+import { GTestCaseInfo, PresetInfo, TargetInfo } from './models';
 import { ConfigurationManager } from './services/configurationManager';
 import { MappingEngine } from './services/mappingEngine';
 import { OutputLogger } from './services/outputLogger';
@@ -15,6 +15,10 @@ import { relativeDisplayPath } from './utils';
 interface TargetQuickPickItem extends vscode.QuickPickItem {
   readonly target?: TargetInfo;
   readonly action?: 'customTextFilter';
+}
+
+interface GTestQuickPickItem extends vscode.QuickPickItem {
+  readonly filterText: string;
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -353,6 +357,62 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     });
   };
 
+  const buildGTestFilterItems = (target: TargetInfo, testCases: readonly GTestCaseInfo[]): GTestQuickPickItem[] => {
+    const suites = new Map<string, GTestCaseInfo[]>();
+    for (const testCase of testCases) {
+      const suiteCases = suites.get(testCase.suite) ?? [];
+      suites.set(testCase.suite, [...suiteCases, testCase]);
+    }
+
+    return [
+      {
+        label: target.displayName,
+        description: path.basename(target.guessedExecutablePath),
+        detail: 'Target executable',
+        filterText: target.displayName,
+      },
+      ...Array.from(suites.entries()).map(([suite, cases]) => ({
+        label: suite,
+        description: `${cases.length} case${cases.length === 1 ? '' : 's'}`,
+        detail: cases.map((testCase) => testCase.name).join(', '),
+        filterText: suite,
+      })),
+      ...testCases.map((testCase) => ({
+        label: testCase.filter,
+        description: testCase.suite,
+        detail: 'GoogleTest case',
+        filterText: testCase.filter,
+      })),
+    ];
+  };
+
+  const pickGTestFilter = async (): Promise<GTestQuickPickItem | undefined> => {
+    const stateMessage = gtestTreeDataProvider.getMessage();
+    if (stateMessage) {
+      void vscode.window.showWarningMessage(stateMessage);
+      return undefined;
+    }
+
+    const target = resolveSelectedTarget();
+    if (!target) {
+      void vscode.window.showWarningMessage('Select a target to filter GoogleTest cases.');
+      return undefined;
+    }
+
+    const testCases = await gtestTreeDataProvider.getAllTestCases(target);
+    if (testCases.length === 0) {
+      void vscode.window.showWarningMessage(`No GoogleTest cases were found in ${target.displayName}.`);
+      return undefined;
+    }
+
+    return vscode.window.showQuickPick(buildGTestFilterItems(target, testCases), {
+      prompt: 'Filter GoogleTest targets, suites, or cases',
+      placeHolder: 'Example: gtest, MathTest, Adds, MathTest.Adds',
+      matchOnDescription: true,
+      matchOnDetail: true,
+    });
+  };
+
   const revealActiveSource = async (filePath: string | undefined): Promise<void> => {
     targetTreeDataProvider.setActiveSourcePath(filePath);
 
@@ -401,16 +461,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       await updateGTestSelection(resolveSelectedTarget());
     }),
     vscode.commands.registerCommand('cmakerunner.filterGTests', async () => {
-      const filterText = await vscode.window.showInputBox({
-        prompt: 'Filter GoogleTest targets or cases',
-        placeHolder: 'Example: gtest, MathTest, Adds, MathTest.Adds',
-        value: gtestTreeDataProvider.getFilterText(),
-      });
-      if (filterText === undefined) {
+      const pick = await pickGTestFilter();
+      if (!pick) {
         return;
       }
 
-      await applyGTestFilter(filterText);
+      await applyGTestFilter(pick.filterText);
     }),
     vscode.commands.registerCommand('cmakerunner.clearGTestFilter', async () => {
       await applyGTestFilter('');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -557,7 +557,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
       if (item instanceof GTestTargetTreeItem) {
         await updateGTestSelection(item.target);
-        await workflowManager.runAllGTestCases(preset, item.target);
+        if (gtestTreeDataProvider.getFilterText()) {
+          const testCases = await gtestTreeDataProvider.getVisibleTestCases(item.target);
+          await workflowManager.runGTestCases(preset, item.target, testCases);
+        } else {
+          await workflowManager.runAllGTestCases(preset, item.target);
+        }
         await updateGTestSelection(item.target);
         return;
       }

--- a/src/services/workflowManager.ts
+++ b/src/services/workflowManager.ts
@@ -124,6 +124,42 @@ export class WorkflowManager {
     await this.taskExecutionEngine.executeRun(runCommand, runLabel, preset.binaryDir);
   }
 
+  public async runGTestCases(
+    preset: PresetInfo,
+    target: TargetInfo,
+    testCases: readonly GTestCaseInfo[],
+    buildFirst = true,
+  ): Promise<void> {
+    const filters = Array.from(new Set(testCases.map((testCase) => testCase.filter).filter(Boolean)));
+    if (filters.length === 0) {
+      void vscode.window.showWarningMessage(`No GoogleTest cases were selected in ${target.displayName}.`);
+      return;
+    }
+
+    if (buildFirst) {
+      const buildVariables = this.createVariables(preset, target);
+      const built = await this.executeBuildStep({
+        command: this.configurationManager.getBuildCommand(buildVariables),
+        label: `Build ${target.displayName} [${preset.name}]`,
+        logName: target.name,
+        displayName: target.displayName,
+        failureVerb: 'Build',
+      });
+      if (!built) {
+        return;
+      }
+    }
+
+    const runVariables = this.createVariables(preset, target);
+    const gtestFilterArgument = `--gtest_filter=${quoteForShell(filters.join(':'))}`;
+    const runCommand = `${this.configurationManager.getRunCommand(runVariables)} ${gtestFilterArgument}`;
+    const runLabel = filters.length === 1
+      ? `Run ${filters[0]} [${preset.name}]`
+      : `Run ${filters.length} GoogleTest cases in ${target.displayName} [${preset.name}]`;
+    this.logger.info(`Launching ${filters.length} filtered GoogleTest case(s) for target ${target.name}`);
+    await this.taskExecutionEngine.executeRun(runCommand, runLabel, preset.binaryDir);
+  }
+
   public async runAllGTestCases(
     preset: PresetInfo,
     target: TargetInfo,

--- a/src/ui/gtestTreeDataProvider.ts
+++ b/src/ui/gtestTreeDataProvider.ts
@@ -84,6 +84,11 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
     return (await this.getVisibleTargets()).length;
   }
 
+  public async getVisibleTestCases(target: TargetInfo): Promise<GTestCaseInfo[]> {
+    const testCases = await this.getTestCases(target);
+    return this.filterVisibleTestCases(target, testCases);
+  }
+
   public getMessage(): string | undefined {
     if (!this.selectedTargetId) {
       return 'Select a target and build it to view GoogleTest cases.';
@@ -107,8 +112,8 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
     }
 
     if (element instanceof GTestTargetTreeItem) {
-      const testCases = await this.getTestCases(element.target);
-      return this.getVisibleTestCases(element.target, testCases)
+      const testCases = await this.getVisibleTestCases(element.target);
+      return testCases
         .map((testCase) => new GTestCaseTreeItem(element.target, testCase));
     }
 
@@ -169,7 +174,7 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
     return this.targets.find((target) => target.id === this.selectedTargetId);
   }
 
-  private getVisibleTestCases(target: TargetInfo, testCases: GTestCaseInfo[]): GTestCaseInfo[] {
+  private filterVisibleTestCases(target: TargetInfo, testCases: GTestCaseInfo[]): GTestCaseInfo[] {
     const query = this.normalizeFilterQuery(this.filterText);
     if (!query || this.matchesTarget(target, query)) {
       return testCases;

--- a/src/ui/gtestTreeDataProvider.ts
+++ b/src/ui/gtestTreeDataProvider.ts
@@ -85,8 +85,12 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
   }
 
   public async getVisibleTestCases(target: TargetInfo): Promise<GTestCaseInfo[]> {
-    const testCases = await this.getTestCases(target);
+    const testCases = await this.getCachedTestCases(target);
     return this.filterVisibleTestCases(target, testCases);
+  }
+
+  public async getAllTestCases(target: TargetInfo): Promise<GTestCaseInfo[]> {
+    return [...await this.getCachedTestCases(target)];
   }
 
   public getMessage(): string | undefined {
@@ -128,7 +132,7 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
     return undefined;
   }
 
-  private async getTestCases(target: TargetInfo): Promise<GTestCaseInfo[]> {
+  private async getCachedTestCases(target: TargetInfo): Promise<GTestCaseInfo[]> {
     if (this.testCasesByTargetId.has(target.id)) {
       return this.testCasesByTargetId.get(target.id) as GTestCaseInfo[];
     }
@@ -157,7 +161,7 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
         continue;
       }
 
-      const testCases = await this.getTestCases(target);
+      const testCases = await this.getCachedTestCases(target);
       if (testCases.some((testCase) => this.matchesTestCase(testCase, query))) {
         visibleTargets.push(target);
       }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -211,12 +211,44 @@ describe('extension commands', () => {
   it('filterGTests applies and clears the gtest view filter', async () => {
     await activateExtension();
 
-    (vscode.window as any).showInputBox = async () => 'MathTest';
-    await vscode.commands.executeCommand('cmakerunner.filterGTests');
+    fs.mkdirSync(path.join(fixtureRoot, 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(fixtureRoot, 'bin', 'app'), '');
+
+    const workflowModule = require('../src/services/workflowManager') as typeof import('../src/services/workflowManager');
+    const originalBuildTarget = workflowModule.WorkflowManager.prototype.buildTarget;
+    const originalListGTestCases = workflowModule.WorkflowManager.prototype.listGTestCases;
+    const pickedLabels: string[][] = [];
+
+    workflowModule.WorkflowManager.prototype.buildTarget = async () => {};
+    workflowModule.WorkflowManager.prototype.listGTestCases = async () => [
+      { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+      { suite: 'MathTest', name: 'Divides', filter: 'MathTest.Divides' },
+      { suite: 'StringTest', name: 'Splits', filter: 'StringTest.Splits' },
+    ];
+    (vscode.window as any).showQuickPick = async (items: readonly { label: string; target?: unknown }[]) => {
+      const quickPickItems = items as Array<{ label: string; target?: unknown }>;
+      pickedLabels.push(quickPickItems.map((item) => item.label));
+      if (quickPickItems.some((item) => item.target)) {
+        return quickPickItems.find((item) => item.label === 'app');
+      }
+
+      return quickPickItems.find((item) => item.label === 'MathTest');
+    };
+
+    try {
+      await vscode.commands.executeCommand('cmakerunner.buildTargetFromCurrentFile');
+      await vscode.commands.executeCommand('cmakerunner.filterGTests');
+    } finally {
+      workflowModule.WorkflowManager.prototype.buildTarget = originalBuildTarget;
+      workflowModule.WorkflowManager.prototype.listGTestCases = originalListGTestCases;
+    }
 
     const gtestsTreeView = mockedVscode.__mock.createdTreeViews.get('cmakerunner.gtests');
     assert.ok(gtestsTreeView);
     assert.strictEqual(gtestsTreeView?.description, 'Filter: MathTest');
+    assert.ok(pickedLabels[1].includes('MathTest.Adds'));
+    assert.ok(pickedLabels[1].includes('MathTest.Divides'));
+    assert.ok(pickedLabels[1].includes('StringTest.Splits'));
 
     await vscode.commands.executeCommand('cmakerunner.clearGTestFilter');
     assert.strictEqual(gtestsTreeView?.description, undefined);
@@ -239,6 +271,7 @@ describe('extension commands', () => {
     workflowModule.WorkflowManager.prototype.buildTarget = async () => {};
     workflowModule.WorkflowManager.prototype.listGTestCases = async () => [
       { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+      { suite: 'MathTest', name: 'Divides', filter: 'MathTest.Divides' },
       { suite: 'StringTest', name: 'Splits', filter: 'StringTest.Splits' },
     ];
     workflowModule.WorkflowManager.prototype.runGTestCases = async (_preset, _target, testCases) => {
@@ -247,11 +280,14 @@ describe('extension commands', () => {
     workflowModule.WorkflowManager.prototype.runAllGTestCases = async () => {
       ranAll = true;
     };
-    (vscode.window as any).showQuickPick = async (items: readonly { label: string }[]) => {
-      const quickPickItems = items as Array<{ label: string }>;
-      return quickPickItems.find((item) => item.label === 'app');
+    (vscode.window as any).showQuickPick = async (items: readonly { label: string; target?: unknown }[]) => {
+      const quickPickItems = items as Array<{ label: string; target?: unknown }>;
+      if (quickPickItems.some((item) => item.target)) {
+        return quickPickItems.find((item) => item.label === 'app');
+      }
+
+      return quickPickItems.find((item) => item.label === 'MathTest');
     };
-    (vscode.window as any).showInputBox = async () => 'MathTest';
 
     try {
       await vscode.commands.executeCommand('cmakerunner.buildTargetFromCurrentFile');
@@ -269,28 +305,42 @@ describe('extension commands', () => {
     }
 
     assert.strictEqual(ranAll, false);
-    assert.deepStrictEqual(filters, ['MathTest.Adds']);
+    assert.deepStrictEqual(filters, ['MathTest.Adds', 'MathTest.Divides']);
   });
 
   it('clears the gtest filter when switching to a different target', async () => {
     await activateExtension();
 
+    fs.mkdirSync(path.join(fixtureRoot, 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(fixtureRoot, 'bin', 'app'), '');
+
     const workflowModule = require('../src/services/workflowManager') as typeof import('../src/services/workflowManager');
     const originalBuildTarget = workflowModule.WorkflowManager.prototype.buildTarget;
+    const originalListGTestCases = workflowModule.WorkflowManager.prototype.listGTestCases;
+    let targetPickCount = 0;
+
     workflowModule.WorkflowManager.prototype.buildTarget = async () => {};
+    workflowModule.WorkflowManager.prototype.listGTestCases = async () => [
+      { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+    ];
 
-    (vscode.window as any).showInputBox = async () => 'MathTest';
-    await vscode.commands.executeCommand('cmakerunner.filterGTests');
+    (vscode.window as any).showQuickPick = async (items: readonly { label: string; target?: unknown }[]) => {
+      const quickPickItems = items as Array<{ label: string; target?: unknown }>;
+      if (quickPickItems.some((item) => item.target)) {
+        targetPickCount += 1;
+        return quickPickItems.find((item) => item.label === (targetPickCount === 1 ? 'app' : 'demo'));
+      }
 
-    (vscode.window as any).showQuickPick = async (items: readonly { label: string }[]) => {
-      const quickPickItems = items as Array<{ label: string }>;
-      return quickPickItems.find((item) => item.label === 'demo');
+      return quickPickItems.find((item) => item.label === 'MathTest');
     };
 
     try {
       await vscode.commands.executeCommand('cmakerunner.buildTargetFromCurrentFile');
+      await vscode.commands.executeCommand('cmakerunner.filterGTests');
+      await vscode.commands.executeCommand('cmakerunner.buildTargetFromCurrentFile');
     } finally {
       workflowModule.WorkflowManager.prototype.buildTarget = originalBuildTarget;
+      workflowModule.WorkflowManager.prototype.listGTestCases = originalListGTestCases;
     }
 
     const gtestsTreeView = mockedVscode.__mock.createdTreeViews.get('cmakerunner.gtests');

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -222,6 +222,56 @@ describe('extension commands', () => {
     assert.strictEqual(gtestsTreeView?.description, undefined);
   });
 
+  it('runGTestCase runs visible filtered cases when invoked from a gtest target', async () => {
+    await activateExtension();
+
+    fs.mkdirSync(path.join(fixtureRoot, 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(fixtureRoot, 'bin', 'app'), '');
+
+    const workflowModule = require('../src/services/workflowManager') as typeof import('../src/services/workflowManager');
+    const originalBuildTarget = workflowModule.WorkflowManager.prototype.buildTarget;
+    const originalListGTestCases = workflowModule.WorkflowManager.prototype.listGTestCases;
+    const originalRunGTestCases = workflowModule.WorkflowManager.prototype.runGTestCases;
+    const originalRunAllGTestCases = workflowModule.WorkflowManager.prototype.runAllGTestCases;
+    let ranAll = false;
+    let filters: string[] = [];
+
+    workflowModule.WorkflowManager.prototype.buildTarget = async () => {};
+    workflowModule.WorkflowManager.prototype.listGTestCases = async () => [
+      { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+      { suite: 'StringTest', name: 'Splits', filter: 'StringTest.Splits' },
+    ];
+    workflowModule.WorkflowManager.prototype.runGTestCases = async (_preset, _target, testCases) => {
+      filters = testCases.map((testCase) => testCase.filter);
+    };
+    workflowModule.WorkflowManager.prototype.runAllGTestCases = async () => {
+      ranAll = true;
+    };
+    (vscode.window as any).showQuickPick = async (items: readonly { label: string }[]) => {
+      const quickPickItems = items as Array<{ label: string }>;
+      return quickPickItems.find((item) => item.label === 'app');
+    };
+    (vscode.window as any).showInputBox = async () => 'MathTest';
+
+    try {
+      await vscode.commands.executeCommand('cmakerunner.buildTargetFromCurrentFile');
+      await vscode.commands.executeCommand('cmakerunner.filterGTests');
+      const gtestsTreeView = mockedVscode.__mock.createdTreeViews.get('cmakerunner.gtests') as any;
+      const provider = gtestsTreeView?.options.treeDataProvider;
+      const [targetItem] = await provider.getChildren();
+
+      await vscode.commands.executeCommand('cmakerunner.runGTestCase', targetItem);
+    } finally {
+      workflowModule.WorkflowManager.prototype.buildTarget = originalBuildTarget;
+      workflowModule.WorkflowManager.prototype.listGTestCases = originalListGTestCases;
+      workflowModule.WorkflowManager.prototype.runGTestCases = originalRunGTestCases;
+      workflowModule.WorkflowManager.prototype.runAllGTestCases = originalRunAllGTestCases;
+    }
+
+    assert.strictEqual(ranAll, false);
+    assert.deepStrictEqual(filters, ['MathTest.Adds']);
+  });
+
   it('clears the gtest filter when switching to a different target', async () => {
     await activateExtension();
 

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -456,6 +456,20 @@ describe('ui', () => {
       assert.strictEqual(await provider.getVisibleTargetCount(), 1);
     });
 
+    it('should expose visible gtest cases for filtered target runs', async () => {
+      const provider = new GTestTreeDataProvider(async () => [
+        { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+        { suite: 'StringTest', name: 'Splits', filter: 'StringTest.Splits' },
+      ]);
+      provider.setTargets([target]);
+      provider.setSelectedTarget(target, true);
+
+      provider.setFilterText('math');
+      const cases = await provider.getVisibleTestCases(target);
+
+      assert.deepStrictEqual(cases.map((testCase) => testCase.filter), ['MathTest.Adds']);
+    });
+
     it('should clear gtest filter text', () => {
       const provider = new GTestTreeDataProvider(async () => []);
       provider.setFilterText('math');

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -320,6 +320,51 @@ describe('workflow manager', () => {
     }
   });
 
+  it('runGTestCases runs selected cases with a combined filter', async () => {
+    const deps = createDeps();
+    let runCommand = '';
+    let runLabel = '';
+    deps.taskExecutionEngine.executeRun = async (command?: string, label?: string) => {
+      runCommand = command ?? '';
+      runLabel = label ?? '';
+      return { exitCode: 0 };
+    };
+
+    const manager = new WorkflowManager(deps.configurationManager as never, deps.taskExecutionEngine as never, deps.logger as never);
+    await manager.runGTestCases(preset, target, [
+      { suite: 'SuiteA', name: 'TestOne', filter: 'SuiteA.TestOne' },
+      { suite: 'SuiteA', name: 'TestTwo', filter: 'SuiteA.TestTwo' },
+    ], false);
+
+    assert.strictEqual(runCommand, '/tmp/build/debug/app --gtest_filter=SuiteA.TestOne:SuiteA.TestTwo');
+    assert.strictEqual(runLabel, 'Run 2 GoogleTest cases in App [debug]');
+  });
+
+  it('runGTestCases does not run when no cases are selected', async () => {
+    const deps = createDeps();
+    let warned = '';
+    let runCount = 0;
+    deps.taskExecutionEngine.executeRun = async () => {
+      runCount += 1;
+      return { exitCode: 0 };
+    };
+
+    const originalShowWarningMessage = vscode.window.showWarningMessage;
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      warned = message;
+      return undefined;
+    };
+
+    try {
+      const manager = new WorkflowManager(deps.configurationManager as never, deps.taskExecutionEngine as never, deps.logger as never);
+      await manager.runGTestCases(preset, target, [], false);
+      assert.ok(warned.includes('No GoogleTest cases were selected'));
+      assert.strictEqual(runCount, 0);
+    } finally {
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
+  });
+
   it('runAllGTestCases runs the target executable without a gtest filter', async () => {
     const deps = createDeps();
     let runCommand = '';


### PR DESCRIPTION
## Summary
- run visible filtered GoogleTest cases when the GTests target Run action is used with an active filter
- keep the unfiltered target Run action behavior for running the full GoogleTest executable
- add provider, workflow, and extension command coverage plus README updates

Fixes #12

## Test
- `PATH="/Users/chenyi/Documents/New project/.tools/bin:$PATH" npm test`