### PR TITLE
Add GTest source navigation and debug action

### DIFF
--- a/README-ALL.md
+++ b/README-ALL.md
@@ -21,6 +21,7 @@ Implementation and architecture notes are available in `doc/architecture.zh-CN.m
 - Reveals the matching source node when the active editor switches to a mapped file
 - Supports target filtering by target name, executable name, or source file name
 - Builds, runs, and debugs targets from the `Targets` view or from the active mapped source file
+- Lists GoogleTest cases for built executable targets, opens a case's source on click, and provides inline run/debug actions
 - Adds an editor title build button that starts from the current file and lets you pick from auto-filtered targets
 - Lets you customize configure, build, and run command templates through `settings.json`
 
@@ -50,7 +51,8 @@ Before using the extension, make sure the workspace meets these conditions:
 2. The project is a working CMake C++ project that can be configured and built
 3. A C/C++ debugging backend is available in VS Code
    - Windows: usually `cppvsdbg`
-   - Linux/macOS: usually `cppdbg`
+   - Linux: usually `cppdbg`
+   - macOS: usually `lldb`
 4. You must successfully run configure at least once so the build directory contains CMake File API reply data
 
 By default, preset configure runs `cmake --preset ${preset}`. The extension writes `.cmake/api/v1/query/codemodel-v2` before configure. Target discovery and source mapping rely on the CMake File API reply.
@@ -140,6 +142,7 @@ The extension currently contributes these commands:
 - `cmakerunner.buildTargetFromCurrentFile`: build the target mapped to the active source file
 - `cmakerunner.runTarget`: build and run the resolved target
 - `cmakerunner.runGTestCase`: build the resolved target, select a GoogleTest case, and run only that case
+- `cmakerunner.debugGTestCase`: build the resolved target, write/update a launch configuration for one GoogleTest case, and start debugging it
 - `cmakerunner.debugTarget`: build and debug the resolved target
 - `cmakerunner.refreshGTests`: clear cached GoogleTest discovery results and reload the GTests view
 - `cmakerunner.filterGTests`: filter visible GoogleTest targets and cases
@@ -158,7 +161,7 @@ The extension exposes these settings in VS Code `settings.json`:
 | `cmakerunner.tasks.buildCommandTemplate` | `cmake --build ${buildDir}${configurationArgument} --target ${target}` | Build command template used for targets |
 | `cmakerunner.tasks.runCommandTemplate` | `${executableCommand}` | Run command template used for targets |
 | `cmakerunner.tasks.clearTerminalBeforeRun` | `true` | Clears the shared terminal before build or run tasks |
-| `cmakerunner.debug.type` | `""` | Debug configuration type written into `launch.json`. Leave empty to use the platform default: `cppvsdbg` on Windows, `cppdbg`/`lldb` on other platforms. |
+| `cmakerunner.debug.type` | `""` | Debug configuration type written into `launch.json`. Leave empty to use the platform default: `cppvsdbg` on Windows, `lldb` on macOS, `cppdbg` on Linux. |
 
 ### Supported variables for configure templates
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It is designed for projects that already use `CMakePresets.json` and want a more
 - Reveals the matching source node when the active editor switches to a mapped file
 - Supports target filtering by target name, executable name, or source file name
 - Builds, runs, and debugs targets from the `Targets` view or from the active mapped source file
+- Lists GoogleTest cases for built executable targets, opens a case's source on click, and provides inline run/debug actions
 - Adds an editor title build button that starts from the current file and lets you pick from auto-filtered targets
 - Lets you customize configure, build, and run command templates through `settings.json`
 
@@ -44,7 +45,8 @@ Before using the extension, make sure the workspace meets these conditions:
 2. The project is a working CMake C++ project that can be configured and built
 3. A C/C++ debugging backend is available in VS Code
    - Windows: usually `cppvsdbg`
-   - Linux/macOS: usually `cppdbg`
+   - Linux: usually `cppdbg`
+   - macOS: usually `lldb`
 
 By default, preset configure runs `cmake --preset ${preset}`. Target discovery and source mapping rely on the configure step completing successfully.
 
@@ -129,6 +131,7 @@ The extension currently contributes these commands:
 - `cmakerunner.buildTargetFromCurrentFile`: build the target mapped to the active source file
 - `cmakerunner.runTarget`: build and run the resolved target
 - `cmakerunner.runGTestCase`: build the resolved target, select a GoogleTest case, and run only that case
+- `cmakerunner.debugGTestCase`: build the resolved target, write/update a launch configuration for one GoogleTest case, and start debugging it
 - `cmakerunner.debugTarget`: build and debug the resolved target
 - `cmakerunner.refreshGTests`: clear cached GoogleTest discovery results and reload the GTests view
 - `cmakerunner.filterGTests`: filter visible GoogleTest targets and cases
@@ -147,7 +150,7 @@ The extension exposes these settings in VS Code `settings.json`:
 | `cmakerunner.tasks.buildCommandTemplate` | `cmake --build ${buildDir}${configurationArgument} --target ${target}` | Build command template used for targets |
 | `cmakerunner.tasks.runCommandTemplate` | `${executableCommand}` | Run command template used for targets |
 | `cmakerunner.tasks.clearTerminalBeforeRun` | `true` | Clears the shared terminal before build or run tasks |
-| `cmakerunner.debug.type` | `""` | Debug configuration type written into `launch.json`. Leave empty to use the platform default: `cppvsdbg` on Windows, `cppdbg`/`lldb` on other platforms. |
+| `cmakerunner.debug.type` | `""` | Debug configuration type written into `launch.json`. Leave empty to use the platform default: `cppvsdbg` on Windows, `lldb` on macOS, `cppdbg` on Linux. |
 
 ### Supported variables for configure templates
 

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -19,6 +19,7 @@
 - 当活动编辑器切换到已映射源码时，在树中定位对应源码节点
 - 支持按目标名、可执行文件名、源码文件名过滤目标
 - 可从 `Targets` 视图或当前已映射源码文件直接执行 build、run、debug
+- 可在 `GTests` 视图中查看已构建目标的 GoogleTest 用例，点击用例跳转源码，并提供单个用例的运行/调试按钮
 - 支持通过 `settings.json` 自定义 configure、build、run 命令模板
 
 ## 典型工作流
@@ -47,7 +48,8 @@
 2. 项目本身是可正常 configure 和 build 的 CMake C++ 工程
 3. VS Code 中已经安装可用的 C/C++ 调试后端
    - Windows：通常为 `cppvsdbg`
-   - Linux/macOS：通常为 `cppdbg`
+   - Linux：通常为 `cppdbg`
+   - macOS：通常为 `lldb`
 4. 至少需要先成功执行一次 configure，让构建目录中生成 CMake File API reply 数据
 
 默认情况下，preset configure 使用 `cmake --preset ${preset}`，并且会在 configure 前写入 `.cmake/api/v1/query/codemodel-v2`。当前目标发现与源码映射主要依赖 CMake File API reply。
@@ -136,6 +138,7 @@ code --install-extension cmakerunner-0.x.x.vsix
 - `cmakerunner.buildTargetFromCurrentFile`：构建当前活动源文件映射到的目标
 - `cmakerunner.runTarget`：构建并运行解析到的目标
 - `cmakerunner.runGTestCase`：构建解析到的目标，选择并运行单个 GoogleTest 用例
+- `cmakerunner.debugGTestCase`：构建解析到的目标，为单个 GoogleTest 用例写入/更新调试配置并启动调试
 - `cmakerunner.debugTarget`：构建并调试解析到的目标
 - `cmakerunner.refreshGTests`：清除 GoogleTest 发现缓存并刷新 GTests 视图
 - `cmakerunner.filterGTests`：过滤可见的 GoogleTest 目标和用例
@@ -154,7 +157,7 @@ code --install-extension cmakerunner-0.x.x.vsix
 | `cmakerunner.tasks.buildCommandTemplate` | `cmake --build ${buildDir}${configurationArgument} --target ${target}` | 目标构建使用的命令模板 |
 | `cmakerunner.tasks.runCommandTemplate` | `${executableCommand}` | 目标运行使用的命令模板 |
 | `cmakerunner.tasks.clearTerminalBeforeRun` | `true` | build 或 run 前是否清理共享终端 |
-| `cmakerunner.debug.type` | `""` | 写入 `launch.json` 的 debug 配置类型。留空则使用平台默认值：Windows 上为 `cppvsdbg`，其他平台为 `cppdbg`/`lldb` |
+| `cmakerunner.debug.type` | `""` | 写入 `launch.json` 的 debug 配置类型。留空则使用平台默认值：Windows 上为 `cppvsdbg`，macOS 上为 `lldb`，Linux 上为 `cppdbg` |
 
 ### configure 模板支持的变量
 

--- a/doc/architecture.zh-CN.md
+++ b/doc/architecture.zh-CN.md
@@ -67,7 +67,7 @@
 2. 插件根据 target、preset、关联的 build preset / configuration 与配置模板生成实际命令
 3. `TaskExecutionEngine` 以 shell task 方式执行任务；构建任务接入 `$gcc` 和 `$msCompile` problem matcher
 4. `Run` 和 `Debug` 默认都会先构建目标；仅当构建成功后才继续运行或启动调试
-5. `Debug` 由 `WorkflowManager` 动态构造 `cppvsdbg` 或 `cppdbg` 配置并发起调试会话
+5. `Debug` 由 `WorkflowManager` 动态构造平台默认调试配置并发起调试会话，Windows 默认为 `cppvsdbg`，macOS 默认为 `lldb`，Linux 默认为 `cppdbg`
 
 ## 5. 配置与扩展性设计
 

--- a/package.json
+++ b/package.json
@@ -121,6 +121,14 @@
                 }
             },
             {
+                "command": "cmakerunner.debugGTestCase",
+                "title": "Debug GTest Case",
+                "icon": {
+                    "light": "resources/debug-light.svg",
+                    "dark": "resources/debug-dark.svg"
+                }
+            },
+            {
                 "command": "cmakerunner.debugTarget",
                 "title": "Debug Target",
                 "icon": {
@@ -229,6 +237,11 @@
                     "command": "cmakerunner.runGTestCase",
                     "when": "view == cmakerunner.gtests && viewItem == gtestCase",
                     "group": "inline@1"
+                },
+                {
+                    "command": "cmakerunner.debugGTestCase",
+                    "when": "view == cmakerunner.gtests && viewItem == gtestCase",
+                    "group": "inline@2"
                 }
             ]
         },
@@ -263,7 +276,7 @@
                 "cmakerunner.debug.type": {
                     "type": "string",
                     "default": "",
-                    "description": "Debug configuration type written into launch.json. Leave empty to use the platform default: cppvsdbg on Windows, cppdbg/lldb on other platforms."
+                    "description": "Debug configuration type written into launch.json. Leave empty to use the platform default: cppvsdbg on Windows, lldb on macOS, cppdbg on Linux."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { MappingEngine } from './services/mappingEngine';
 import { OutputLogger } from './services/outputLogger';
 import { PresetProvider } from './services/presetProvider';
 import { TaskExecutionEngine } from './services/taskExecutionEngine';
+import { findGTestSourceLocation } from './services/gtestSourceLocator';
 import { WorkflowManager } from './services/workflowManager';
 import { GTestCaseTreeItem, GTestTargetTreeItem, GTestTreeDataProvider } from './ui/gtestTreeDataProvider';
 import { PresetTreeDataProvider, PresetTreeItem } from './ui/presetTreeDataProvider';
@@ -437,6 +438,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
   };
 
+  const openGTestCaseSource = async (item: GTestCaseTreeItem): Promise<void> => {
+    const location = await findGTestSourceLocation(item.testCase, item.target.sourceFiles);
+    if (!location) {
+      logger.warn(`Unable to locate source for GoogleTest case ${item.testCase.filter}`);
+      void vscode.window.showWarningMessage(`Unable to locate source for GoogleTest case ${item.testCase.filter}.`);
+      return;
+    }
+
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.file(location.filePath));
+    const editor = await vscode.window.showTextDocument(document);
+    const position = new vscode.Position(location.line, location.character);
+    editor.selection = new vscode.Selection(position, position);
+    editor.revealRange(new vscode.Range(position, position), vscode.TextEditorRevealType.InCenter);
+  };
+
   context.subscriptions.push(
     vscode.commands.registerCommand('cmakerunner.refresh', async () => {
       await refresh(currentPreset?.name);
@@ -470,6 +486,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand('cmakerunner.clearGTestFilter', async () => {
       await applyGTestFilter('');
+    }),
+    vscode.commands.registerCommand('cmakerunner.openGTestCaseSource', async (item?: GTestCaseTreeItem) => {
+      if (!(item instanceof GTestCaseTreeItem)) {
+        return;
+      }
+
+      await openGTestCaseSource(item);
     }),
     vscode.commands.registerCommand('cmakerunner.selectPreset', async (item?: PresetTreeItem) => {
       if (!item) {
@@ -631,6 +654,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       await selectTarget(target);
       await workflowManager.runGTestCase(preset, target);
       await updateGTestSelection(target);
+    }),
+    vscode.commands.registerCommand('cmakerunner.debugGTestCase', async (item?: GTestCaseTreeItem) => {
+      const preset = ensurePreset();
+      if (!preset || !(item instanceof GTestCaseTreeItem)) {
+        return;
+      }
+
+      await updateGTestSelection(item.target);
+      await workflowManager.debugGTestCase(preset, item.target, item.testCase);
+      await updateGTestSelection(item.target);
     }),
     vscode.commands.registerCommand('cmakerunner.debugTarget', async (item?: TargetTreeItem | SourceTreeItem) => {
       const preset = ensurePreset();

--- a/src/services/configurationManager.ts
+++ b/src/services/configurationManager.ts
@@ -27,7 +27,11 @@ export class ConfigurationManager {
       return configuredDebugType;
     }
 
-    return process.platform === 'win32' ? 'cppvsdbg' : 'cppdbg';
+    if (process.platform === 'win32') {
+      return 'cppvsdbg';
+    }
+
+    return process.platform === 'darwin' ? 'lldb' : 'cppdbg';
   }
 
   public resolveDebugProgram(variables: TaskVariables): string {

--- a/src/services/gtestSourceLocator.ts
+++ b/src/services/gtestSourceLocator.ts
@@ -1,0 +1,124 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { GTestCaseInfo } from '../models';
+import { decodeTextBufferCandidates } from '../utils';
+
+export interface GTestSourceLocation {
+  readonly filePath: string;
+  readonly line: number;
+  readonly character: number;
+}
+
+interface MacroMatch {
+  readonly index: number;
+}
+
+const sourceFileExtensions = new Set([
+  '.c',
+  '.cc',
+  '.cpp',
+  '.cxx',
+  '.h',
+  '.hh',
+  '.hpp',
+  '.hxx',
+]);
+
+const gtestMacroPattern = /\b(?:TEST|TEST_F|TEST_P|TYPED_TEST|TYPED_TEST_P)\s*\(\s*([A-Za-z_]\w*)\s*,\s*([A-Za-z_]\w*)/g;
+
+export async function findGTestSourceLocation(
+  testCase: GTestCaseInfo,
+  sourceFiles: readonly string[],
+): Promise<GTestSourceLocation | undefined> {
+  const suiteCandidates = getSuiteCandidates(testCase.suite);
+  const nameCandidates = getNameCandidates(testCase.name);
+
+  for (const sourceFile of sourceFiles) {
+    if (!isCxxSourceFile(sourceFile)) {
+      continue;
+    }
+
+    const contents = await readTextFileCandidates(sourceFile);
+    if (contents.length === 0) {
+      continue;
+    }
+
+    for (const content of contents) {
+      const match = findMacroMatch(content, suiteCandidates, nameCandidates);
+      if (!match) {
+        continue;
+      }
+
+      const position = getLineAndCharacter(content, match.index);
+      return {
+        filePath: sourceFile,
+        line: position.line,
+        character: position.character,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function findMacroMatch(
+  content: string,
+  suiteCandidates: readonly string[],
+  nameCandidates: readonly string[],
+): MacroMatch | undefined {
+  gtestMacroPattern.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = gtestMacroPattern.exec(content)) !== null) {
+    const [, suite, name] = match;
+    if (nameCandidates.includes(name) && suiteCandidates.includes(suite)) {
+      return {
+        index: match.index,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function getSuiteCandidates(suite: string): string[] {
+  const candidates = new Set<string>([suite]);
+  const suiteParts = suite.split('/').filter(Boolean);
+  for (const suitePart of suiteParts) {
+    candidates.add(suitePart);
+  }
+
+  return [...candidates];
+}
+
+function getNameCandidates(testName: string): string[] {
+  const candidates = new Set<string>([testName]);
+  const nameParts = testName.split('/').filter(Boolean);
+  if (nameParts[0]) {
+    candidates.add(nameParts[0]);
+  }
+
+  return [...candidates];
+}
+
+function isCxxSourceFile(filePath: string): boolean {
+  return sourceFileExtensions.has(path.extname(filePath).toLowerCase());
+}
+
+async function readTextFileCandidates(filePath: string): Promise<string[]> {
+  try {
+    const content = await fs.readFile(filePath);
+    return decodeTextBufferCandidates(content).map((decoded) => decoded.text);
+  } catch {
+    return [];
+  }
+}
+
+function getLineAndCharacter(content: string, index: number): { line: number; character: number } {
+  const before = content.slice(0, index);
+  const lines = before.split(/\r?\n/);
+  return {
+    line: lines.length - 1,
+    character: lines[lines.length - 1].length,
+  };
+}

--- a/src/services/workflowManager.ts
+++ b/src/services/workflowManager.ts
@@ -196,6 +196,29 @@ export class WorkflowManager {
     await this.taskExecutionEngine.executeRun(runCommand, runLabel, preset.binaryDir);
   }
 
+  public async debugGTestCase(
+    preset: PresetInfo,
+    target: TargetInfo,
+    testCase: GTestCaseInfo,
+    buildFirst = true,
+  ): Promise<void> {
+    if (buildFirst) {
+      const buildVariables = this.createVariables(preset, target);
+      const built = await this.executeBuildStep({
+        command: this.configurationManager.getBuildCommand(buildVariables),
+        label: `Build ${target.displayName} [${preset.name}]`,
+        logName: target.name,
+        displayName: target.displayName,
+        failureVerb: 'Build',
+      });
+      if (!built) {
+        return;
+      }
+    }
+
+    await this.prepareGTestDebugging(preset, target, testCase);
+  }
+
   public async debugTarget(preset: PresetInfo, target: TargetInfo): Promise<void> {
     const buildVariables = this.createVariables(preset, target);
     const built = await this.executeBuildStep({
@@ -208,6 +231,49 @@ export class WorkflowManager {
 
     if (built) {
       await this.prepareDebugging(preset, target);
+    }
+  }
+
+  private async prepareGTestDebugging(preset: PresetInfo, target: TargetInfo, testCase: GTestCaseInfo): Promise<void> {
+    const variables = this.createVariables(preset, target);
+    const program = this.configurationManager.resolveDebugProgram(variables);
+    const debugType = this.configurationManager.getDebugType();
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+
+    if (!workspaceFolder) {
+      this.logger.warn(`Unable to write launch.json because no workspace folder is available for ${target.name}`);
+      void vscode.window.showWarningMessage(`Unable to prepare launch.json for ${testCase.filter} because no workspace folder is open.`);
+      return;
+    }
+
+    await this.ensureLaunchJsonExists(workspaceFolder);
+
+    const configurationName = `Debug ${testCase.filter}`;
+    const launchConfiguration = {
+      name: configurationName,
+      type: debugType,
+      expressions: debugType == 'lldb' ? 'native': undefined,
+      request: 'launch',
+      program,
+      cwd: path.dirname(program || target.guessedExecutablePath),
+      args: [`--gtest_filter=${testCase.filter}`],
+      env: {
+        ASAN_OPTIONS: 'detect_leaks=0',
+        LSAN_OPTIONS: 'detect_leaks=0',
+      },
+    };
+
+    const launchSettings = vscode.workspace.getConfiguration('launch', workspaceFolder.uri);
+    const existingConfigurations = launchSettings.get<Record<string, unknown>[]>('configurations', []);
+    const nextConfigurations = existingConfigurations.filter((configuration) => configuration?.name !== configurationName);
+    nextConfigurations.push(launchConfiguration);
+
+    await launchSettings.update('configurations', nextConfigurations, vscode.ConfigurationTarget.WorkspaceFolder);
+    this.logger.info(`Updated launch.json for GoogleTest case ${testCase.filter}. configuration=${configurationName}, program=${program}`);
+
+    const started = await vscode.debug.startDebugging(workspaceFolder, launchConfiguration);
+    if (!started) {
+      void vscode.window.showInformationMessage(`Debug configuration '${configurationName}' has been added to launch.json.`);
     }
   }
 
@@ -280,6 +346,22 @@ export class WorkflowManager {
 
     if (action === 'Open Run and Debug') {
       await vscode.commands.executeCommand('workbench.view.debug');
+    }
+  }
+
+  private async ensureLaunchJsonExists(workspaceFolder: vscode.WorkspaceFolder): Promise<void> {
+    const vscodeDirUri = vscode.Uri.joinPath(workspaceFolder.uri, '.vscode');
+    const launchJsonUri = vscode.Uri.joinPath(vscodeDirUri, 'launch.json');
+
+    try {
+      await vscode.workspace.fs.stat(launchJsonUri);
+      return;
+    } catch {
+      await vscode.workspace.fs.createDirectory(vscodeDirUri);
+      await vscode.workspace.fs.writeFile(
+        launchJsonUri,
+        Buffer.from(JSON.stringify({ version: '0.2.0', configurations: [] }, null, 2)),
+      );
     }
   }
 

--- a/src/ui/gtestTreeDataProvider.ts
+++ b/src/ui/gtestTreeDataProvider.ts
@@ -23,6 +23,11 @@ export class GTestCaseTreeItem extends vscode.TreeItem {
     this.tooltip = testCase.filter;
     this.contextValue = 'gtestCase';
     this.iconPath = new vscode.ThemeIcon('testing-passed-icon');
+    this.command = {
+      command: 'cmakerunner.openGTestCaseSource',
+      title: 'Open GTest Source',
+      arguments: [this],
+    };
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,16 @@
 import * as path from 'path';
 
 type JsonEncoding = 'utf8' | 'utf16le' | 'utf16be';
+type TextEncoding = JsonEncoding | 'gb18030' | 'gbk' | 'gb2312';
 
 interface ParsedJsonBuffer<T> {
   readonly value: T;
   readonly encoding: JsonEncoding;
+}
+
+interface DecodedTextBuffer {
+  readonly text: string;
+  readonly encoding: TextEncoding;
 }
 
 export function normalizePath(filePath: string): string {
@@ -91,6 +97,33 @@ export function parseJsonBuffer<T>(content: Uint8Array): ParsedJsonBuffer<T> {
     : new Error('Unable to parse JSON content with supported encodings');
 }
 
+export function decodeTextBuffer(content: Uint8Array): DecodedTextBuffer {
+  const [decoded] = decodeTextBufferCandidates(content);
+  if (decoded) {
+    return decoded;
+  }
+
+  throw new Error('Unable to decode text content with supported encodings');
+}
+
+export function decodeTextBufferCandidates(content: Uint8Array): DecodedTextBuffer[] {
+  const buffer = Buffer.from(content);
+  const candidates: DecodedTextBuffer[] = [];
+
+  for (const encoding of getTextEncodingCandidates(buffer)) {
+    try {
+      candidates.push({
+        text: decodeBuffer(buffer, encoding).replace(/^\uFEFF/, ''),
+        encoding,
+      });
+    } catch {
+      // Unsupported or incompatible encodings are skipped.
+    }
+  }
+
+  return candidates;
+}
+
 function getJsonEncodingCandidates(buffer: Buffer): JsonEncoding[] {
   const candidates: JsonEncoding[] = [];
 
@@ -112,12 +145,42 @@ function getJsonEncodingCandidates(buffer: Buffer): JsonEncoding[] {
 }
 
 function decodeJsonBuffer(buffer: Buffer, encoding: JsonEncoding): string {
+  return decodeBuffer(buffer, encoding);
+}
+
+function getTextEncodingCandidates(buffer: Buffer): TextEncoding[] {
+  const candidates: TextEncoding[] = [];
+  const [bomEncoding] = getJsonEncodingCandidates(buffer);
+  if (bomEncoding && hasEncodingBom(buffer, bomEncoding)) {
+    candidates.push(bomEncoding);
+  }
+
+  for (const encoding of ['utf8', 'gb18030', 'gbk', 'gb2312', 'utf16le', 'utf16be'] as const) {
+    if (!candidates.includes(encoding)) {
+      candidates.push(encoding);
+    }
+  }
+
+  return candidates;
+}
+
+function hasEncodingBom(buffer: Buffer, encoding: JsonEncoding): boolean {
+  return (encoding === 'utf8' && buffer.length >= 3 && buffer[0] === 0xef && buffer[1] === 0xbb && buffer[2] === 0xbf)
+    || (encoding === 'utf16le' && buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xfe)
+    || (encoding === 'utf16be' && buffer.length >= 2 && buffer[0] === 0xfe && buffer[1] === 0xff);
+}
+
+function decodeBuffer(buffer: Buffer, encoding: TextEncoding): string {
   if (encoding === 'utf8') {
-    return new TextDecoder('utf-8').decode(buffer);
+    return new TextDecoder('utf-8', { fatal: true }).decode(buffer);
   }
 
   if (encoding === 'utf16le') {
-    return new TextDecoder('utf-16le').decode(buffer);
+    return new TextDecoder('utf-16le', { fatal: true }).decode(buffer);
+  }
+
+  if (encoding === 'gb18030' || encoding === 'gbk' || encoding === 'gb2312') {
+    return new TextDecoder(encoding, { fatal: true }).decode(buffer);
   }
 
   const swapped = Buffer.from(buffer);
@@ -127,5 +190,5 @@ function decodeJsonBuffer(buffer: Buffer, encoding: JsonEncoding): string {
     swapped[index + 1] = first;
   }
 
-  return new TextDecoder('utf-16le').decode(swapped);
+  return new TextDecoder('utf-16le', { fatal: true }).decode(swapped);
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { GTestCaseTreeItem } from '../src/ui/gtestTreeDataProvider';
 
 type MockVscode = typeof vscode & {
   __mock: {
@@ -27,6 +28,7 @@ describe('extension commands', () => {
   const originalWorkspaceFolders = vscode.workspace.workspaceFolders;
   const originalShowQuickPick = vscode.window.showQuickPick;
   const originalShowInputBox = vscode.window.showInputBox;
+  const originalShowTextDocument = vscode.window.showTextDocument;
 
   before(() => {
     fs.mkdirSync(sourceDir, { recursive: true });
@@ -101,6 +103,7 @@ describe('extension commands', () => {
   afterEach(() => {
     (vscode.window as { showQuickPick: typeof vscode.window.showQuickPick }).showQuickPick = originalShowQuickPick;
     (vscode.window as { showInputBox: typeof vscode.window.showInputBox }).showInputBox = originalShowInputBox;
+    (vscode.window as { showTextDocument: typeof vscode.window.showTextDocument }).showTextDocument = originalShowTextDocument;
     (vscode.workspace as { workspaceFolders?: typeof vscode.workspace.workspaceFolders }).workspaceFolders = originalWorkspaceFolders;
   });
 
@@ -199,6 +202,68 @@ describe('extension commands', () => {
     }
 
     assert.strictEqual(gtestTargetName, 'app');
+  });
+
+  it('openGTestCaseSource opens the matching source file', async () => {
+    await activateExtension();
+
+    fs.writeFileSync(appSourcePath, [
+      '#include <gtest/gtest.h>',
+      '',
+      'TEST(MathTest, Adds) {',
+      '  ASSERT_TRUE(true);',
+      '}',
+    ].join('\n'));
+
+    let shownEditor: vscode.TextEditor | undefined;
+    (vscode.window as any).showTextDocument = async (document: vscode.TextDocument) => {
+      shownEditor = {
+        document,
+        revealRange: () => undefined,
+      } as unknown as vscode.TextEditor;
+      return shownEditor;
+    };
+
+    const item = new GTestCaseTreeItem({
+      id: 'app',
+      name: 'app',
+      displayName: 'app',
+      sourceFiles: [appSourcePath],
+      guessedExecutablePath: path.join(fixtureRoot, 'bin', 'app'),
+    }, { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' });
+
+    await vscode.commands.executeCommand('cmakerunner.openGTestCaseSource', item);
+
+    assert.strictEqual(shownEditor?.document.uri.fsPath, appSourcePath);
+    assert.strictEqual(shownEditor?.selection.active.line, 2);
+  });
+
+  it('debugGTestCase delegates the selected tree item to the workflow manager', async () => {
+    await activateExtension();
+
+    const workflowModule = require('../src/services/workflowManager') as typeof import('../src/services/workflowManager');
+    const originalDebugGTestCase = workflowModule.WorkflowManager.prototype.debugGTestCase;
+    let debuggedFilter: string | undefined;
+
+    workflowModule.WorkflowManager.prototype.debugGTestCase = async (_preset, _target, testCase) => {
+      debuggedFilter = testCase.filter;
+    };
+
+    const item = new GTestCaseTreeItem({
+      id: 'app',
+      name: 'app',
+      displayName: 'app',
+      sourceFiles: [appSourcePath],
+      guessedExecutablePath: path.join(fixtureRoot, 'bin', 'app'),
+    }, { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' });
+
+    try {
+      await vscode.commands.executeCommand('cmakerunner.debugGTestCase', item);
+    } finally {
+      workflowModule.WorkflowManager.prototype.debugGTestCase = originalDebugGTestCase;
+    }
+
+    assert.strictEqual(debuggedFilter, 'MathTest.Adds');
   });
 
   it('creates a GTests view alongside the Targets view', async () => {

--- a/test/gtestSourceLocator.test.ts
+++ b/test/gtestSourceLocator.test.ts
@@ -1,0 +1,107 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { findGTestSourceLocation } from '../src/services/gtestSourceLocator';
+
+describe('gtest source locator', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cmakerunner-gtest-source-'));
+
+  after(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('finds a concrete GoogleTest macro in target sources', async () => {
+    const sourcePath = path.join(tempRoot, 'math_test.cpp');
+    fs.writeFileSync(sourcePath, [
+      '#include <gtest/gtest.h>',
+      '',
+      'TEST_F(MathTest, Adds) {',
+      '  ASSERT_EQ(2, 1 + 1);',
+      '}',
+    ].join('\n'));
+
+    const location = await findGTestSourceLocation(
+      { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+      [sourcePath],
+    );
+
+    assert.deepStrictEqual(location, {
+      filePath: sourcePath,
+      line: 2,
+      character: 0,
+    });
+  });
+
+  it('matches typed and parameterized suite names reported with suffixes', async () => {
+    const sourcePath = path.join(tempRoot, 'typed_test.cc');
+    fs.writeFileSync(sourcePath, [
+      '#include <gtest/gtest.h>',
+      '',
+      'TYPED_TEST(',
+      '  TypedSuite,',
+      '  Works',
+      ') {',
+      '  SUCCEED();',
+      '}',
+    ].join('\n'));
+
+    const location = await findGTestSourceLocation(
+      { suite: 'TypedSuite/0', name: 'Works', filter: 'TypedSuite/0.Works' },
+      [sourcePath],
+    );
+
+    assert.strictEqual(location?.filePath, sourcePath);
+    assert.strictEqual(location?.line, 2);
+  });
+
+  it('matches value-parameterized test names reported with instance suffixes', async () => {
+    const sourcePath = path.join(tempRoot, 'parameterized_test.cpp');
+    fs.writeFileSync(sourcePath, [
+      '#include <gtest/gtest.h>',
+      '',
+      'TEST_P(MathFixture, Adds) {',
+      '  ASSERT_TRUE(true);',
+      '}',
+    ].join('\n'));
+
+    const location = await findGTestSourceLocation(
+      { suite: 'AllInputs/MathFixture', name: 'Adds/0', filter: 'AllInputs/MathFixture.Adds/0' },
+      [sourcePath],
+    );
+
+    assert.strictEqual(location?.filePath, sourcePath);
+    assert.strictEqual(location?.line, 2);
+  });
+
+  it('finds macros in GBK encoded source files', async () => {
+    const sourcePath = path.join(tempRoot, 'gbk_test.cpp');
+    const gbkComment = Buffer.from([0x2f, 0x2f, 0x20, 0xd6, 0xd0, 0xce, 0xc4, 0x0a]);
+    const asciiSource = Buffer.from([
+      'TEST(MathTest, Adds) {',
+      '  ASSERT_TRUE(true);',
+      '}',
+    ].join('\n'));
+    fs.writeFileSync(sourcePath, Buffer.concat([gbkComment, asciiSource]));
+
+    const location = await findGTestSourceLocation(
+      { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+      [sourcePath],
+    );
+
+    assert.strictEqual(location?.filePath, sourcePath);
+    assert.strictEqual(location?.line, 1);
+  });
+
+  it('ignores missing files and non-C/C++ sources', async () => {
+    const notesPath = path.join(tempRoot, 'notes.txt');
+    fs.writeFileSync(notesPath, 'TEST(MathTest, Adds) {}\n');
+
+    const location = await findGTestSourceLocation(
+      { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+      [path.join(tempRoot, 'missing.cpp'), notesPath],
+    );
+
+    assert.strictEqual(location, undefined);
+  });
+});

--- a/test/run-unit.js
+++ b/test/run-unit.js
@@ -8,6 +8,7 @@ const testFiles = [
   'out/test/utils.test.js',
   'out/test/models.test.js',
   'out/test/services.test.js',
+  'out/test/gtestSourceLocator.test.js',
   'out/test/ui.test.js',
   'out/test/integration.test.js',
   'out/test/workflow.test.js',

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -396,7 +396,7 @@ describe('ui', () => {
       assert.strictEqual(cases.length, 1);
       assert.ok(cases[0] instanceof GTestCaseTreeItem);
       assert.strictEqual(cases[0].contextValue, 'gtestCase');
-      assert.strictEqual(cases[0].command, undefined);
+      assert.strictEqual(cases[0].command?.command, 'cmakerunner.openGTestCaseSource');
     });
 
     it('should cache discovered cases until refresh', async () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -209,4 +209,13 @@ describe('utils', () => {
       assert.throws(() => utils.parseJsonBuffer(buffer));
     });
   });
+
+  describe('decodeTextBuffer', () => {
+    it('should decode GBK compatible text when UTF-8 is invalid', () => {
+      const buffer = Buffer.from([0xd6, 0xd0, 0xce, 0xc4]);
+      const result = utils.decodeTextBuffer(buffer);
+      assert.strictEqual(result.text, '中文');
+      assert.strictEqual(result.encoding, 'gb18030');
+    });
+  });
 });

--- a/test/vscode-mock.js
+++ b/test/vscode-mock.js
@@ -28,6 +28,7 @@ const vscode = {
       inspect: (key) => ({ key, defaultValue: undefined, globalValue: undefined, workspaceValue: undefined }),
     }),
     workspaceFolders: [{ uri: { fsPath: projectRoot } }],
+    openTextDocument: async (uri) => ({ uri }),
     fs: {
       readFile: async (uri) => fs.promises.readFile(uri.fsPath),
       readDirectory: async (uri) => {
@@ -79,6 +80,11 @@ const vscode = {
     showErrorMessage: async (msg) => undefined,
     showQuickPick: async (items) => items?.[0],
     showInputBox: async () => undefined,
+    showTextDocument: async (document) => ({
+      document,
+      selection: undefined,
+      revealRange: () => undefined,
+    }),
     activeTextEditor: undefined,
     onDidChangeActiveTextEditor: () => ({ dispose: () => {} }),
   },
@@ -111,6 +117,7 @@ const vscode = {
   Uri: {
     file: (fsPath) => ({ fsPath }),
     parse: (uri) => ({ fsPath: uri }),
+    joinPath: (base, ...segments) => ({ fsPath: path.join(base.fsPath, ...segments) }),
   },
 
   EventEmitter: class {
@@ -143,6 +150,30 @@ const vscode = {
   TaskGroup: { Build: {}, Clean: {}, Test: {} },
   TaskScope: { Workspace: 2 },
   ConfigurationTarget: { Global: 1, Workspace: 2, WorkspaceFolder: 3 },
+  TextEditorRevealType: { Default: 0, InCenter: 1, InCenterIfOutsideViewport: 2, AtTop: 3 },
+
+  Position: class {
+    constructor(line, character) {
+      this.line = line;
+      this.character = character;
+    }
+  },
+
+  Range: class {
+    constructor(start, end) {
+      this.start = start;
+      this.end = end;
+    }
+  },
+
+  Selection: class {
+    constructor(anchor, active) {
+      this.anchor = anchor;
+      this.active = active;
+      this.start = anchor;
+      this.end = active;
+    }
+  },
 
   Task: class {
     constructor(definition, scope, name, source, execution, problemMatchers) {

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -1,5 +1,8 @@
 import * as assert from 'assert';
 import type { ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { PresetInfo, TargetInfo } from '../src/models';
 import { parseGTestListOutput, WorkflowManager } from '../src/services/workflowManager';
@@ -385,6 +388,74 @@ describe('workflow manager', () => {
       assert.strictEqual(runCommand, '/tmp/build/debug/app');
     } finally {
       (childProcess as any).execFile = originalExecFile;
+    }
+  });
+
+  it('debugGTestCase writes launch configuration and starts the selected test case', async () => {
+    const deps = createDeps();
+    deps.configurationManager.getDebugType = () => 'lldb';
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cmakerunner-workflow-'));
+    const existingConfiguration = {
+      name: 'Keep Me',
+      type: 'cppdbg',
+      request: 'launch',
+      program: '/tmp/keep',
+    };
+    let updatedConfigurations: Record<string, unknown>[] = [];
+    let startedConfiguration: Record<string, unknown> | undefined;
+
+    const originalWorkspaceFolders = vscode.workspace.workspaceFolders;
+    const originalGetConfiguration = vscode.workspace.getConfiguration;
+    const originalStartDebugging = vscode.debug.startDebugging;
+
+    (vscode.workspace as { workspaceFolders?: typeof vscode.workspace.workspaceFolders }).workspaceFolders = [
+      { uri: { fsPath: tempRoot } } as unknown as vscode.WorkspaceFolder,
+    ];
+    (vscode.workspace as any).getConfiguration = (section?: string, scope?: vscode.Uri) => {
+      if (section === 'launch' && scope) {
+        return {
+          get: () => [existingConfiguration],
+          update: async (_key: string, value: Record<string, unknown>[]) => {
+            updatedConfigurations = value;
+          },
+        };
+      }
+      return originalGetConfiguration(section as never, scope);
+    };
+    (vscode.debug as any).startDebugging = async (_folder: vscode.WorkspaceFolder, configuration: Record<string, unknown>) => {
+      startedConfiguration = configuration;
+      return true;
+    };
+
+    try {
+      const manager = new WorkflowManager(deps.configurationManager as never, deps.taskExecutionEngine as never, deps.logger as never);
+      await manager.debugGTestCase(preset, target, { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' }, false);
+    } finally {
+      (vscode.workspace as { workspaceFolders?: typeof vscode.workspace.workspaceFolders }).workspaceFolders = originalWorkspaceFolders;
+      (vscode.workspace as any).getConfiguration = originalGetConfiguration;
+      (vscode.debug as any).startDebugging = originalStartDebugging;
+    }
+
+    try {
+      assert.ok(fs.existsSync(path.join(tempRoot, '.vscode', 'launch.json')));
+      assert.strictEqual(updatedConfigurations.length, 2);
+      assert.deepStrictEqual(updatedConfigurations[0], existingConfiguration);
+      assert.deepStrictEqual(updatedConfigurations[1], {
+        name: 'Debug MathTest.Adds',
+        type: 'lldb',
+        expressions: 'native',
+        request: 'launch',
+        program: '/tmp/build/debug/app',
+        cwd: '/tmp/build/debug',
+        args: ['--gtest_filter=MathTest.Adds'],
+        env: {
+          ASAN_OPTIONS: 'detect_leaks=0',
+          LSAN_OPTIONS: 'detect_leaks=0',
+        },
+      });
+      assert.deepStrictEqual(startedConfiguration, updatedConfigurations[1]);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Summary
- make concrete GTest tree items open their matching TEST/TEST_F/TEST_P/TYPED_TEST source location on click
- add an inline Debug action for GTest cases that creates .vscode/launch.json when needed, writes a per-case --gtest_filter launch config, and starts debugging
- cover source lookup, debug config creation, tree command wiring, and docs

## Tests
- PATH="/Users/chenyi/Documents/New project/.tools/bin:$PATH" npm test

Fixes #14