### PR TITLE
Default Linux debug configurations to lldb

### DIFF
--- a/README-ALL.md
+++ b/README-ALL.md
@@ -51,7 +51,7 @@ Before using the extension, make sure the workspace meets these conditions:
 2. The project is a working CMake C++ project that can be configured and built
 3. A C/C++ debugging backend is available in VS Code
    - Windows: usually `cppvsdbg`
-   - Linux: usually `cppdbg`
+   - Linux: usually `lldb`
    - macOS: usually `lldb`
 4. You must successfully run configure at least once so the build directory contains CMake File API reply data
 
@@ -161,7 +161,7 @@ The extension exposes these settings in VS Code `settings.json`:
 | `cmakerunner.tasks.buildCommandTemplate` | `cmake --build ${buildDir}${configurationArgument} --target ${target}` | Build command template used for targets |
 | `cmakerunner.tasks.runCommandTemplate` | `${executableCommand}` | Run command template used for targets |
 | `cmakerunner.tasks.clearTerminalBeforeRun` | `true` | Clears the shared terminal before build or run tasks |
-| `cmakerunner.debug.type` | `""` | Debug configuration type written into `launch.json`. Leave empty to use the platform default: `cppvsdbg` on Windows, `lldb` on macOS, `cppdbg` on Linux. |
+| `cmakerunner.debug.type` | `""` | Debug configuration type written into `launch.json`. Leave empty to use the platform default: `cppvsdbg` on Windows, `lldb` on Linux/macOS. |
 
 ### Supported variables for configure templates
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Before using the extension, make sure the workspace meets these conditions:
 2. The project is a working CMake C++ project that can be configured and built
 3. A C/C++ debugging backend is available in VS Code
    - Windows: usually `cppvsdbg`
-   - Linux: usually `cppdbg`
+   - Linux: usually `lldb`
    - macOS: usually `lldb`
 
 By default, preset configure runs `cmake --preset ${preset}`. Target discovery and source mapping rely on the configure step completing successfully.
@@ -150,7 +150,7 @@ The extension exposes these settings in VS Code `settings.json`:
 | `cmakerunner.tasks.buildCommandTemplate` | `cmake --build ${buildDir}${configurationArgument} --target ${target}` | Build command template used for targets |
 | `cmakerunner.tasks.runCommandTemplate` | `${executableCommand}` | Run command template used for targets |
 | `cmakerunner.tasks.clearTerminalBeforeRun` | `true` | Clears the shared terminal before build or run tasks |
-| `cmakerunner.debug.type` | `""` | Debug configuration type written into `launch.json`. Leave empty to use the platform default: `cppvsdbg` on Windows, `lldb` on macOS, `cppdbg` on Linux. |
+| `cmakerunner.debug.type` | `""` | Debug configuration type written into `launch.json`. Leave empty to use the platform default: `cppvsdbg` on Windows, `lldb` on Linux/macOS. |
 
 ### Supported variables for configure templates
 

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -48,7 +48,7 @@
 2. 项目本身是可正常 configure 和 build 的 CMake C++ 工程
 3. VS Code 中已经安装可用的 C/C++ 调试后端
    - Windows：通常为 `cppvsdbg`
-   - Linux：通常为 `cppdbg`
+   - Linux：通常为 `lldb`
    - macOS：通常为 `lldb`
 4. 至少需要先成功执行一次 configure，让构建目录中生成 CMake File API reply 数据
 
@@ -157,7 +157,7 @@ code --install-extension cmakerunner-0.x.x.vsix
 | `cmakerunner.tasks.buildCommandTemplate` | `cmake --build ${buildDir}${configurationArgument} --target ${target}` | 目标构建使用的命令模板 |
 | `cmakerunner.tasks.runCommandTemplate` | `${executableCommand}` | 目标运行使用的命令模板 |
 | `cmakerunner.tasks.clearTerminalBeforeRun` | `true` | build 或 run 前是否清理共享终端 |
-| `cmakerunner.debug.type` | `""` | 写入 `launch.json` 的 debug 配置类型。留空则使用平台默认值：Windows 上为 `cppvsdbg`，macOS 上为 `lldb`，Linux 上为 `cppdbg` |
+| `cmakerunner.debug.type` | `""` | 写入 `launch.json` 的 debug 配置类型。留空则使用平台默认值：Windows 上为 `cppvsdbg`，Linux/macOS 上为 `lldb` |
 
 ### configure 模板支持的变量
 

--- a/doc/architecture.zh-CN.md
+++ b/doc/architecture.zh-CN.md
@@ -67,7 +67,7 @@
 2. 插件根据 target、preset、关联的 build preset / configuration 与配置模板生成实际命令
 3. `TaskExecutionEngine` 以 shell task 方式执行任务；构建任务接入 `$gcc` 和 `$msCompile` problem matcher
 4. `Run` 和 `Debug` 默认都会先构建目标；仅当构建成功后才继续运行或启动调试
-5. `Debug` 由 `WorkflowManager` 动态构造平台默认调试配置并发起调试会话，Windows 默认为 `cppvsdbg`，macOS 默认为 `lldb`，Linux 默认为 `cppdbg`
+5. `Debug` 由 `WorkflowManager` 动态构造平台默认调试配置并发起调试会话，Windows 默认为 `cppvsdbg`，Linux/macOS 默认为 `lldb`
 
 ## 5. 配置与扩展性设计
 

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
                 "cmakerunner.debug.type": {
                     "type": "string",
                     "default": "",
-                    "description": "Debug configuration type written into launch.json. Leave empty to use the platform default: cppvsdbg on Windows, lldb on macOS, cppdbg on Linux."
+                    "description": "Debug configuration type written into launch.json. Leave empty to use the platform default: cppvsdbg on Windows, lldb on Linux/macOS."
                 }
             }
         }

--- a/src/services/configurationManager.ts
+++ b/src/services/configurationManager.ts
@@ -31,7 +31,7 @@ export class ConfigurationManager {
       return 'cppvsdbg';
     }
 
-    return process.platform === 'darwin' ? 'lldb' : 'cppdbg';
+    return 'lldb';
   }
 
   public resolveDebugProgram(variables: TaskVariables): string {

--- a/test/services.test.ts
+++ b/test/services.test.ts
@@ -98,6 +98,18 @@ it('should call appendLine for info level', () => {
       } as unknown as vscode.WorkspaceConfiguration;
     };
 
+    const withMockPlatform = <T>(platform: NodeJS.Platform, run: () => T): T => {
+      const originalDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: platform });
+      try {
+        return run();
+      } finally {
+        if (originalDescriptor) {
+          Object.defineProperty(process, 'platform', originalDescriptor);
+        }
+      }
+    };
+
     it('should get preset configure command with variables', () => {
       const mockConfig = createMockConfig({
         'tasks.presetConfigureCommandTemplate': 'cmake --preset ${preset} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
@@ -186,6 +198,60 @@ it('should call appendLine for info level', () => {
       assert.strictEqual(result, true);
 
       vscode.workspace.getConfiguration = originalGetConfig;
+    });
+
+    it('should default debug type to lldb on Linux and macOS', () => {
+      const mockConfig = createMockConfig({
+        'debug.type': '',
+      });
+
+      const originalGetConfig = vscode.workspace.getConfiguration;
+      (vscode.workspace as any).getConfiguration = () => mockConfig;
+
+      try {
+        withMockPlatform('linux', () => {
+          assert.strictEqual(new ConfigurationManager().getDebugType(), 'lldb');
+        });
+        withMockPlatform('darwin', () => {
+          assert.strictEqual(new ConfigurationManager().getDebugType(), 'lldb');
+        });
+      } finally {
+        vscode.workspace.getConfiguration = originalGetConfig;
+      }
+    });
+
+    it('should default debug type to cppvsdbg on Windows', () => {
+      const mockConfig = createMockConfig({
+        'debug.type': '',
+      });
+
+      const originalGetConfig = vscode.workspace.getConfiguration;
+      (vscode.workspace as any).getConfiguration = () => mockConfig;
+
+      try {
+        withMockPlatform('win32', () => {
+          assert.strictEqual(new ConfigurationManager().getDebugType(), 'cppvsdbg');
+        });
+      } finally {
+        vscode.workspace.getConfiguration = originalGetConfig;
+      }
+    });
+
+    it('should use configured debug type when provided', () => {
+      const mockConfig = createMockConfig({
+        'debug.type': 'cppdbg',
+      });
+
+      const originalGetConfig = vscode.workspace.getConfiguration;
+      (vscode.workspace as any).getConfiguration = () => mockConfig;
+
+      try {
+        withMockPlatform('linux', () => {
+          assert.strictEqual(new ConfigurationManager().getDebugType(), 'cppdbg');
+        });
+      } finally {
+        vscode.workspace.getConfiguration = originalGetConfig;
+      }
     });
 
     it('should resolve debug program from run command', () => {


### PR DESCRIPTION
## Summary
- change the default non-Windows debug type so Linux now emits "type": "lldb"
- keep Windows defaulting to "cppvsdbg" and preserve explicit cmakerunner.debug.type overrides
- update docs and package configuration text to match the new defaults

## Tests
- PATH="/Users/chenyi/Documents/New project/.tools/bin:$PATH" npm test

Fixes #16