### PR TITLE
Support regex filters for Targets and GTests

### DIFF
--- a/README-ALL.md
+++ b/README-ALL.md
@@ -115,6 +115,7 @@ Expanding a target runs it with `--gtest_list_tests`. Use the inline `Run` actio
 discovered case to run the same target with `--gtest_filter=<suite.case>`.
 Use `Filter` to choose from the current target, discovered suites, or discovered cases. It matches
 target names, executable names, suite names, case names, or full `suite.case` filters.
+You can also type a regular expression and press Enter to keep every matching GoogleTest visible.
 When a filter is active, the target-level `Run` action runs only the
 visible GoogleTest cases. Use `Clear Filter` to remove the filter, and `Refresh` to clear
 cached discovery results.
@@ -128,6 +129,7 @@ Use `Filter` in the **Targets** view to open a target picker that is auto-filter
 - source file name
 - relative source path
 
+You can also type a regular expression and press Enter to keep every matching target visible.
 Use `Clear Filter` to remove the current filter.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Use `Filter` in the **Targets** view to open a target picker that is auto-filter
 - source file name
 - relative source path
 
+You can also type a regular expression and press Enter to keep every matching target visible.
 Use `Clear Filter` to remove the current filter.
 
 ### 7. Run one GoogleTest case
@@ -115,6 +116,7 @@ Expanding a target runs it with `--gtest_list_tests`. Use the inline `Run` actio
 discovered case to run the same target with `--gtest_filter=<suite.case>`.
 Use `Filter` to choose from the current target, discovered suites, or discovered cases. It matches
 target names, executable names, suite names, case names, or full `suite.case` filters.
+You can also type a regular expression and press Enter to keep every matching GoogleTest visible.
 When a filter is active, the target-level `Run` action runs only the
 visible GoogleTest cases. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached discovery results.
 

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -112,7 +112,8 @@ code --install-extension cmakerunner-0.x.x.vsix
 `Run` 操作，会用 `--gtest_filter=<suite.case>` 只运行该用例。
 使用 `Filter` 会展示当前目标、已发现的 suite 和已发现的 case，并可按目标名、
 可执行文件名、suite 名、case 名或完整 `suite.case` 过滤。过滤生效时，目标右侧的
-`Run` 操作只会运行当前可见的 GoogleTest 用例；使用 `Clear Filter` 清除过滤；使用 `Refresh`
+`Run` 操作只会运行当前可见的 GoogleTest 用例。你也可以直接输入正则表达式并回车，
+保留所有匹配的 GoogleTest；使用 `Clear Filter` 清除过滤；使用 `Refresh`
 清除已缓存的用例发现结果。
 
 ### 7. 过滤目标
@@ -124,6 +125,7 @@ code --install-extension cmakerunner-0.x.x.vsix
 - 源码文件名
 - 相对源码路径
 
+你也可以直接输入正则表达式并回车，保留所有匹配的目标。
 使用 `Clear Filter` 可清除当前过滤条件。
 
 ## 命令列表

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { PresetProvider } from './services/presetProvider';
 import { TaskExecutionEngine } from './services/taskExecutionEngine';
 import { findGTestSourceLocation } from './services/gtestSourceLocator';
 import { WorkflowManager } from './services/workflowManager';
+import { getRegexFilterError } from './ui/filterMatcher';
 import { GTestCaseTreeItem, GTestTargetTreeItem, GTestTreeDataProvider } from './ui/gtestTreeDataProvider';
 import { PresetTreeDataProvider, PresetTreeItem } from './ui/presetTreeDataProvider';
 import { SourceTreeItem, TargetTreeDataProvider, TargetTreeItem } from './ui/targetTreeDataProvider';
@@ -15,12 +16,19 @@ import { relativeDisplayPath } from './utils';
 
 interface TargetQuickPickItem extends vscode.QuickPickItem {
   readonly target?: TargetInfo;
-  readonly action?: 'customTextFilter';
 }
 
 interface GTestQuickPickItem extends vscode.QuickPickItem {
   readonly filterText: string;
 }
+
+interface RegexFilterQuickPickItem extends vscode.QuickPickItem {
+  readonly regexText: string;
+}
+
+type RegexFilterPick<T extends vscode.QuickPickItem> =
+  | { readonly type: 'item'; readonly item: T }
+  | { readonly type: 'regex'; readonly filterText: string };
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
@@ -64,21 +72,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const updateTargetViewState = async (): Promise<void> => {
     const filterText = targetTreeDataProvider.getFilterText();
-    targetsTreeView.description = filterText ? `Filter: ${filterText}` : undefined;
+    targetsTreeView.description = filterText
+      ? `${targetTreeDataProvider.isFilterRegex() ? 'Regex' : 'Filter'}: ${filterText}`
+      : undefined;
     targetsTreeView.message = filterText && targetTreeDataProvider.getVisibleTargetCount() === 0
       ? 'No executable target matches the current filter.'
       : undefined;
     await vscode.commands.executeCommand('setContext', 'cmakerunner.targetsFilterActive', !!filterText);
   };
 
-  const applyTargetFilter = async (filterText: string): Promise<void> => {
-    targetTreeDataProvider.setFilterText(filterText);
+  const applyTargetFilter = async (filterText: string, options?: { isRegex?: boolean }): Promise<void> => {
+    targetTreeDataProvider.setFilterText(filterText, options);
     await updateTargetViewState();
   };
 
   const updateGTestViewState = async (): Promise<void> => {
     const filterText = gtestTreeDataProvider.getFilterText();
-    gtestsTreeView.description = filterText ? `Filter: ${filterText}` : undefined;
+    gtestsTreeView.description = filterText
+      ? `${gtestTreeDataProvider.isFilterRegex() ? 'Regex' : 'Filter'}: ${filterText}`
+      : undefined;
     const stateMessage = gtestTreeDataProvider.getMessage();
     gtestsTreeView.message = stateMessage ?? (
       filterText && await gtestTreeDataProvider.getVisibleTargetCount() === 0
@@ -88,8 +100,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     await vscode.commands.executeCommand('setContext', 'cmakerunner.gtestsFilterActive', !!filterText);
   };
 
-  const applyGTestFilter = async (filterText: string): Promise<void> => {
-    gtestTreeDataProvider.setFilterText(filterText);
+  const applyGTestFilter = async (filterText: string, options?: { isRegex?: boolean }): Promise<void> => {
+    gtestTreeDataProvider.setFilterText(filterText, options);
     await updateGTestViewState();
   };
 
@@ -358,6 +370,115 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     });
   };
 
+  const pickRegexFilter = async <T extends vscode.QuickPickItem>(
+    items: readonly T[],
+    options: {
+      readonly title: string;
+      readonly placeHolder: string;
+      readonly regexDetail: string;
+      readonly matchOnDescription?: boolean;
+      readonly matchOnDetail?: boolean;
+    },
+  ): Promise<RegexFilterPick<T> | undefined> => {
+    return new Promise((resolve) => {
+      const quickPick = vscode.window.createQuickPick<T | RegexFilterQuickPickItem>();
+      let settled = false;
+
+      const finish = (result: RegexFilterPick<T> | undefined): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve(result);
+        quickPick.hide();
+        quickPick.dispose();
+      };
+
+      const createRegexItem = (regexText: string): RegexFilterQuickPickItem => ({
+        label: `$(regex) Apply regex: ${regexText}`,
+        description: 'Press Enter to show all matches',
+        detail: options.regexDetail,
+        alwaysShow: true,
+        regexText,
+      });
+
+      const updateItems = (value: string): void => {
+        const regexText = value.trim();
+        if (!regexText) {
+          quickPick.items = [...items];
+          return;
+        }
+
+        const regexItem = createRegexItem(regexText);
+        quickPick.items = [regexItem, ...items];
+        quickPick.activeItems = [regexItem];
+      };
+
+      quickPick.title = options.title;
+      quickPick.value = '';
+      quickPick.placeholder = options.placeHolder;
+      quickPick.ignoreFocusOut = true;
+      quickPick.matchOnDescription = options.matchOnDescription ?? false;
+      quickPick.matchOnDetail = options.matchOnDetail ?? false;
+      quickPick.items = [...items];
+      quickPick.onDidChangeValue(updateItems);
+      quickPick.onDidAccept(() => {
+        const pickedItem = quickPick.selectedItems[0] ?? quickPick.activeItems[0];
+        if (!pickedItem) {
+          finish(undefined);
+          return;
+        }
+
+        if ('regexText' in pickedItem) {
+          const error = getRegexFilterError(pickedItem.regexText);
+          if (error) {
+            void vscode.window.showWarningMessage(`Invalid regular expression: ${error}`);
+            finish(undefined);
+            return;
+          }
+
+          finish({
+            type: 'regex',
+            filterText: pickedItem.regexText,
+          });
+          return;
+        }
+
+        finish({
+          type: 'item',
+          item: pickedItem as T,
+        });
+      });
+      quickPick.onDidHide(() => finish(undefined));
+      quickPick.show();
+    });
+  };
+
+  const pickTargetFilter = async (): Promise<RegexFilterPick<TargetQuickPickItem> | undefined> => {
+    const targets = getAutoFilteredTargets(false);
+    if (!ensureDiscoveredTargets(targets)) {
+      return undefined;
+    }
+
+    const quickPickSourceDir = currentPreset?.sourceDir ?? workspaceRoot;
+    const items: TargetQuickPickItem[] = targets.map((target) => ({
+      label: target.displayName,
+      description: path.basename(target.guessedExecutablePath),
+      detail: `${target.sourceFiles.length} source file${target.sourceFiles.length === 1 ? '' : 's'}: ${target.sourceFiles
+        .map((sourcePath) => relativeDisplayPath(sourcePath, quickPickSourceDir))
+        .join(', ')}`,
+      target,
+    }));
+
+    return pickRegexFilter(items, {
+      title: 'Filter Targets',
+      placeHolder: 'Example: app, main\\.cpp, ^Test.*',
+      regexDetail: 'Match target names, executable names, and source paths',
+      matchOnDescription: true,
+      matchOnDetail: true,
+    });
+  };
+
   const buildGTestFilterItems = (target: TargetInfo, testCases: readonly GTestCaseInfo[]): GTestQuickPickItem[] => {
     const suites = new Map<string, GTestCaseInfo[]>();
     for (const testCase of testCases) {
@@ -387,7 +508,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     ];
   };
 
-  const pickGTestFilter = async (): Promise<GTestQuickPickItem | undefined> => {
+  const pickGTestFilter = async (): Promise<RegexFilterPick<GTestQuickPickItem> | undefined> => {
     const stateMessage = gtestTreeDataProvider.getMessage();
     if (stateMessage) {
       void vscode.window.showWarningMessage(stateMessage);
@@ -406,9 +527,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       return undefined;
     }
 
-    return vscode.window.showQuickPick(buildGTestFilterItems(target, testCases), {
-      prompt: 'Filter GoogleTest targets, suites, or cases',
-      placeHolder: 'Example: gtest, MathTest, Adds, MathTest.Adds',
+    return pickRegexFilter(buildGTestFilterItems(target, testCases), {
+      title: 'Filter GTests',
+      placeHolder: 'Example: MathTest, Math.*Adds, ^StringTest\\.',
+      regexDetail: 'Match target names, suites, case names, and full filters',
       matchOnDescription: true,
       matchOnDetail: true,
     });
@@ -458,14 +580,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       await refresh(currentPreset?.name);
     }),
     vscode.commands.registerCommand('cmakerunner.filterTargets', async () => {
-      const pick = await pickTarget();
+      const pick = await pickTargetFilter();
       if (!pick) {
         return;
       }
 
-      if (pick.target) {
-        await applyTargetFilter(pick.target.displayName);
-        await selectTarget(pick.target);
+      if (pick.type === 'regex') {
+        await applyTargetFilter(pick.filterText, { isRegex: true });
+        return;
+      }
+
+      if (pick.item.target) {
+        await applyTargetFilter(pick.item.target.displayName);
+        await selectTarget(pick.item.target);
         return;
       }
     }),
@@ -482,7 +609,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         return;
       }
 
-      await applyGTestFilter(pick.filterText);
+      if (pick.type === 'regex') {
+        await applyGTestFilter(pick.filterText, { isRegex: true });
+        return;
+      }
+
+      await applyGTestFilter(pick.item.filterText);
     }),
     vscode.commands.registerCommand('cmakerunner.clearGTestFilter', async () => {
       await applyGTestFilter('');

--- a/src/ui/filterMatcher.ts
+++ b/src/ui/filterMatcher.ts
@@ -1,0 +1,41 @@
+export interface FilterMatcher {
+  readonly text: string;
+  readonly isRegex: boolean;
+  matches(value: string): boolean;
+}
+
+export function createFilterMatcher(
+  filterText: string,
+  isRegex: boolean,
+  normalizeValue: (value: string) => string,
+): FilterMatcher | undefined {
+  const trimmed = filterText.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (isRegex) {
+    const regex = new RegExp(trimmed, 'i');
+    return {
+      text: trimmed,
+      isRegex: true,
+      matches: (value) => regex.test(normalizeValue(value)),
+    };
+  }
+
+  const query = normalizeValue(trimmed);
+  return {
+    text: trimmed,
+    isRegex: false,
+    matches: (value) => normalizeValue(value).includes(query),
+  };
+}
+
+export function getRegexFilterError(filterText: string): string | undefined {
+  try {
+    new RegExp(filterText.trim());
+    return undefined;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/src/ui/gtestTreeDataProvider.ts
+++ b/src/ui/gtestTreeDataProvider.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { GTestCaseInfo, TargetInfo } from '../models';
 import { normalizePath } from '../utils';
+import { FilterMatcher, createFilterMatcher } from './filterMatcher';
 
 export class GTestTargetTreeItem extends vscode.TreeItem {
   public constructor(public readonly target: TargetInfo) {
@@ -39,6 +40,7 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
   private targetItems = new Map<string, GTestTargetTreeItem>();
   private testCasesByTargetId = new Map<string, GTestCaseInfo[]>();
   private filterText = '';
+  private filterIsRegex = false;
   private selectedTargetId?: string;
   private selectedTargetBuilt = false;
 
@@ -76,13 +78,18 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
     this.onDidChangeTreeDataEmitter.fire();
   }
 
-  public setFilterText(filterText: string): void {
+  public setFilterText(filterText: string, options?: { isRegex?: boolean }): void {
     this.filterText = filterText.trim();
+    this.filterIsRegex = !!this.filterText && options?.isRegex === true;
     this.onDidChangeTreeDataEmitter.fire();
   }
 
   public getFilterText(): string {
     return this.filterText;
+  }
+
+  public isFilterRegex(): boolean {
+    return this.filterIsRegex;
   }
 
   public async getVisibleTargetCount(): Promise<number> {
@@ -154,20 +161,20 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
       return [];
     }
 
-    const query = this.normalizeFilterQuery(this.filterText);
-    if (!query) {
+    const matcher = this.createFilterMatcher();
+    if (!matcher) {
       return [selectedTarget];
     }
 
     const visibleTargets: TargetInfo[] = [];
     for (const target of [selectedTarget]) {
-      if (this.matchesTarget(target, query)) {
+      if (this.matchesTarget(target, matcher)) {
         visibleTargets.push(target);
         continue;
       }
 
       const testCases = await this.getCachedTestCases(target);
-      if (testCases.some((testCase) => this.matchesTestCase(testCase, query))) {
+      if (testCases.some((testCase) => this.matchesTestCase(testCase, matcher))) {
         visibleTargets.push(target);
       }
     }
@@ -184,24 +191,28 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
   }
 
   private filterVisibleTestCases(target: TargetInfo, testCases: GTestCaseInfo[]): GTestCaseInfo[] {
-    const query = this.normalizeFilterQuery(this.filterText);
-    if (!query || this.matchesTarget(target, query)) {
+    const matcher = this.createFilterMatcher();
+    if (!matcher || this.matchesTarget(target, matcher)) {
       return testCases;
     }
 
-    return testCases.filter((testCase) => this.matchesTestCase(testCase, query));
+    return testCases.filter((testCase) => this.matchesTestCase(testCase, matcher));
   }
 
-  private matchesTarget(target: TargetInfo, query: string): boolean {
-    return this.normalizeFilterQuery(target.displayName).includes(query)
-      || this.normalizeFilterQuery(target.name).includes(query)
-      || this.normalizeFilterQuery(path.basename(target.guessedExecutablePath)).includes(query);
+  private matchesTarget(target: TargetInfo, matcher: FilterMatcher): boolean {
+    return matcher.matches(target.displayName)
+      || matcher.matches(target.name)
+      || matcher.matches(path.basename(target.guessedExecutablePath));
   }
 
-  private matchesTestCase(testCase: GTestCaseInfo, query: string): boolean {
-    return this.normalizeFilterQuery(testCase.suite).includes(query)
-      || this.normalizeFilterQuery(testCase.name).includes(query)
-      || this.normalizeFilterQuery(testCase.filter).includes(query);
+  private matchesTestCase(testCase: GTestCaseInfo, matcher: FilterMatcher): boolean {
+    return matcher.matches(testCase.suite)
+      || matcher.matches(testCase.name)
+      || matcher.matches(testCase.filter);
+  }
+
+  private createFilterMatcher(): FilterMatcher | undefined {
+    return createFilterMatcher(this.filterText, this.filterIsRegex, (value) => this.normalizeFilterQuery(value));
   }
 
   private normalizeFilterQuery(value: string): string {

--- a/src/ui/targetTreeDataProvider.ts
+++ b/src/ui/targetTreeDataProvider.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { TargetInfo } from '../models';
 import { normalizePath, relativeDisplayPath } from '../utils';
+import { FilterMatcher, createFilterMatcher } from './filterMatcher';
 
 export class TargetTreeItem extends vscode.TreeItem {
   public constructor(public readonly target: TargetInfo) {
@@ -42,6 +43,7 @@ export class TargetTreeDataProvider implements vscode.TreeDataProvider<Node> {
   private sourceDir = '';
   private activeSourcePath?: string;
   private filterText = '';
+  private filterIsRegex = false;
   private targetItems = new Map<string, TargetTreeItem>();
   private sourceItems = new Map<string, SourceTreeItem>();
 
@@ -61,14 +63,19 @@ export class TargetTreeDataProvider implements vscode.TreeDataProvider<Node> {
     this.onDidChangeTreeDataEmitter.fire();
   }
 
-  public setFilterText(filterText: string): void {
+  public setFilterText(filterText: string, options?: { isRegex?: boolean }): void {
     this.filterText = filterText.trim();
+    this.filterIsRegex = !!this.filterText && options?.isRegex === true;
     this.rebuildCache();
     this.onDidChangeTreeDataEmitter.fire();
   }
 
   public getFilterText(): string {
     return this.filterText;
+  }
+
+  public isFilterRegex(): boolean {
+    return this.filterIsRegex;
   }
 
   public getVisibleTargetCount(): number {
@@ -120,7 +127,8 @@ export class TargetTreeDataProvider implements vscode.TreeDataProvider<Node> {
   }
 
   private rebuildCache(): void {
-    this.filteredTargets = this.targets.filter((target) => this.matchesTarget(target));
+    const matcher = this.createFilterMatcher();
+    this.filteredTargets = this.targets.filter((target) => this.matchesTarget(target, matcher));
     this.targetItems = new Map(this.filteredTargets.map((target) => [target.id, new TargetTreeItem(target)]));
     this.sourceItems = new Map();
 
@@ -134,33 +142,36 @@ export class TargetTreeDataProvider implements vscode.TreeDataProvider<Node> {
     }
   }
 
-  private matchesTarget(target: TargetInfo): boolean {
-    const query = this.normalizeFilterQuery(this.filterText);
-    if (!query) {
+  private matchesTarget(target: TargetInfo, matcher: FilterMatcher | undefined): boolean {
+    if (!matcher) {
       return true;
     }
 
-    return this.matchesTargetName(target, query) || target.sourceFiles.some((sourcePath) => this.matchesSourcePath(sourcePath, query));
+    return this.matchesTargetName(target, matcher) || target.sourceFiles.some((sourcePath) => this.matchesSourcePath(sourcePath, matcher));
   }
 
   private getVisibleSourceFiles(target: TargetInfo): string[] {
-    const query = this.normalizeFilterQuery(this.filterText);
-    if (!query || this.matchesTargetName(target, query)) {
+    const matcher = this.createFilterMatcher();
+    if (!matcher || this.matchesTargetName(target, matcher)) {
       return target.sourceFiles;
     }
 
-    return target.sourceFiles.filter((sourcePath) => this.matchesSourcePath(sourcePath, query));
+    return target.sourceFiles.filter((sourcePath) => this.matchesSourcePath(sourcePath, matcher));
   }
 
-  private matchesTargetName(target: TargetInfo, query: string): boolean {
-    return this.normalizeFilterQuery(target.displayName).includes(query)
-      || this.normalizeFilterQuery(target.name).includes(query)
-      || this.normalizeFilterQuery(path.basename(target.guessedExecutablePath)).includes(query);
+  private matchesTargetName(target: TargetInfo, matcher: FilterMatcher): boolean {
+    return matcher.matches(target.displayName)
+      || matcher.matches(target.name)
+      || matcher.matches(path.basename(target.guessedExecutablePath));
   }
 
-  private matchesSourcePath(sourcePath: string, query: string): boolean {
-    return this.normalizeFilterQuery(path.basename(sourcePath)).includes(query)
-      || this.normalizeFilterQuery(relativeDisplayPath(sourcePath, this.sourceDir)).includes(query);
+  private matchesSourcePath(sourcePath: string, matcher: FilterMatcher): boolean {
+    return matcher.matches(path.basename(sourcePath))
+      || matcher.matches(relativeDisplayPath(sourcePath, this.sourceDir));
+  }
+
+  private createFilterMatcher(): FilterMatcher | undefined {
+    return createFilterMatcher(this.filterText, this.filterIsRegex, (value) => this.normalizeFilterQuery(value));
   }
 
   private normalizeFilterQuery(value: string): string {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -10,7 +10,19 @@ type MockVscode = typeof vscode & {
     readonly createdTreeViews: Map<string, {
       description?: string;
       message?: string;
+      options?: {
+        treeDataProvider?: unknown;
+      };
     }>;
+    setQuickPickController(controller: ((quickPick: {
+      readonly items: readonly vscode.QuickPickItem[];
+      selectedItems: readonly vscode.QuickPickItem[];
+      activeItems: readonly vscode.QuickPickItem[];
+    }, controls: {
+      changeValue(value: string): void;
+      accept(): void;
+      hide(): void;
+    }) => void) | undefined): void;
     reset(): void;
   };
 };
@@ -29,6 +41,41 @@ describe('extension commands', () => {
   const originalShowQuickPick = vscode.window.showQuickPick;
   const originalShowInputBox = vscode.window.showInputBox;
   const originalShowTextDocument = vscode.window.showTextDocument;
+
+  type MockQuickPick = {
+    readonly items: readonly vscode.QuickPickItem[];
+    selectedItems: readonly vscode.QuickPickItem[];
+    activeItems: readonly vscode.QuickPickItem[];
+  };
+
+  const setQuickPickItemSelection = (
+    label: string,
+    onItems?: (items: readonly vscode.QuickPickItem[]) => void,
+  ): void => {
+    mockedVscode.__mock.setQuickPickController((quickPick: MockQuickPick, controls) => {
+      onItems?.(quickPick.items);
+      const item = quickPick.items.find((candidate) => candidate.label === label);
+      (quickPick as { selectedItems: readonly vscode.QuickPickItem[] }).selectedItems = item ? [item] : [];
+      (quickPick as { activeItems: readonly vscode.QuickPickItem[] }).activeItems = item ? [item] : [];
+      controls.accept();
+    });
+  };
+
+  const captureQuickPickItems = (onItems: (items: readonly vscode.QuickPickItem[]) => void): void => {
+    mockedVscode.__mock.setQuickPickController((quickPick: MockQuickPick, controls) => {
+      onItems(quickPick.items);
+      controls.hide();
+    });
+  };
+
+  const setRegexQuickPickInput = (value: string): void => {
+    mockedVscode.__mock.setQuickPickController((quickPick: MockQuickPick, controls) => {
+      controls.changeValue(value);
+      (quickPick as { selectedItems: readonly vscode.QuickPickItem[] }).selectedItems = [];
+      (quickPick as { activeItems: readonly vscode.QuickPickItem[] }).activeItems = [quickPick.items[0]];
+      controls.accept();
+    });
+  };
 
   before(() => {
     fs.mkdirSync(sourceDir, { recursive: true });
@@ -153,11 +200,9 @@ describe('extension commands', () => {
     await activateExtension();
 
     const pickedLabels: string[] = [];
-    (vscode.window as any).showQuickPick = async (items: readonly { label: string }[]) => {
-      const quickPickItems = items as Array<{ label: string }>;
-      pickedLabels.push(...quickPickItems.map((item) => item.label));
-      return quickPickItems.find((item) => item.label === 'demo');
-    };
+    setQuickPickItemSelection('demo', (items) => {
+      pickedLabels.push(...items.map((item) => item.label));
+    });
 
     await vscode.commands.executeCommand('cmakerunner.filterTargets');
 
@@ -171,10 +216,9 @@ describe('extension commands', () => {
     await activateExtension();
 
     const pickedItems: Array<{ label: string; detail?: string }> = [];
-    (vscode.window as any).showQuickPick = async (items: readonly { label: string; detail?: string }[]) => {
+    captureQuickPickItems((items) => {
       pickedItems.push(...items as Array<{ label: string; detail?: string }>);
-      return undefined;
-    };
+    });
 
     await vscode.commands.executeCommand('cmakerunner.filterTargets');
 
@@ -183,6 +227,43 @@ describe('extension commands', () => {
     assert.ok(appItem?.detail?.includes(path.join('src', 'app.cpp')));
     assert.ok(demoItem?.detail?.includes(path.join('src', 'demo.cpp')));
     assert.ok(appItem?.detail?.includes(path.join('src', 'common.cpp')));
+  });
+
+  it('filterTargets applies typed regular expressions to all matching targets', async () => {
+    await activateExtension();
+
+    setRegexQuickPickInput('^(app|demo)$');
+
+    await vscode.commands.executeCommand('cmakerunner.filterTargets');
+
+    const targetsTreeView = mockedVscode.__mock.createdTreeViews.get('cmakerunner.targets') as any;
+    const provider = targetsTreeView?.options.treeDataProvider;
+    const children = await provider.getChildren();
+
+    assert.strictEqual(targetsTreeView?.description, 'Regex: ^(app|demo)$');
+    assert.deepStrictEqual(children.map((item: { label: string }) => item.label), ['app', 'demo']);
+  });
+
+  it('filterTargets warns and keeps the current filter when the typed regex is invalid', async () => {
+    await activateExtension();
+
+    let warning = '';
+    const originalShowWarningMessage = vscode.window.showWarningMessage;
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      warning = message;
+      return undefined;
+    };
+    setRegexQuickPickInput('[');
+
+    try {
+      await vscode.commands.executeCommand('cmakerunner.filterTargets');
+    } finally {
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
+
+    const targetsTreeView = mockedVscode.__mock.createdTreeViews.get('cmakerunner.targets');
+    assert.ok(warning.includes('Invalid regular expression'));
+    assert.strictEqual(targetsTreeView?.description, undefined);
   });
 
   it('runGTestCase resolves the active source file target', async () => {
@@ -293,12 +374,11 @@ describe('extension commands', () => {
     (vscode.window as any).showQuickPick = async (items: readonly { label: string; target?: unknown }[]) => {
       const quickPickItems = items as Array<{ label: string; target?: unknown }>;
       pickedLabels.push(quickPickItems.map((item) => item.label));
-      if (quickPickItems.some((item) => item.target)) {
-        return quickPickItems.find((item) => item.label === 'app');
-      }
-
-      return quickPickItems.find((item) => item.label === 'MathTest');
+      return quickPickItems.find((item) => item.label === 'app');
     };
+    setQuickPickItemSelection('MathTest', (items) => {
+      pickedLabels.push(items.map((item) => item.label));
+    });
 
     try {
       await vscode.commands.executeCommand('cmakerunner.buildTargetFromCurrentFile');
@@ -317,6 +397,45 @@ describe('extension commands', () => {
 
     await vscode.commands.executeCommand('cmakerunner.clearGTestFilter');
     assert.strictEqual(gtestsTreeView?.description, undefined);
+  });
+
+  it('filterGTests applies typed regular expressions to all matching test cases', async () => {
+    await activateExtension();
+
+    fs.mkdirSync(path.join(fixtureRoot, 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(fixtureRoot, 'bin', 'app'), '');
+
+    const workflowModule = require('../src/services/workflowManager') as typeof import('../src/services/workflowManager');
+    const originalBuildTarget = workflowModule.WorkflowManager.prototype.buildTarget;
+    const originalListGTestCases = workflowModule.WorkflowManager.prototype.listGTestCases;
+
+    workflowModule.WorkflowManager.prototype.buildTarget = async () => {};
+    workflowModule.WorkflowManager.prototype.listGTestCases = async () => [
+      { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+      { suite: 'MathTest', name: 'Divides', filter: 'MathTest.Divides' },
+      { suite: 'StringTest', name: 'Splits', filter: 'StringTest.Splits' },
+    ];
+    (vscode.window as any).showQuickPick = async (items: readonly { label: string; target?: unknown }[]) => {
+      const quickPickItems = items as Array<{ label: string; target?: unknown }>;
+      return quickPickItems.find((item) => item.label === 'app');
+    };
+    setRegexQuickPickInput('^MathTest\\.');
+
+    try {
+      await vscode.commands.executeCommand('cmakerunner.buildTargetFromCurrentFile');
+      await vscode.commands.executeCommand('cmakerunner.filterGTests');
+
+      const gtestsTreeView = mockedVscode.__mock.createdTreeViews.get('cmakerunner.gtests') as any;
+      const provider = gtestsTreeView?.options.treeDataProvider;
+      const [targetItem] = await provider.getChildren();
+      const cases = await provider.getChildren(targetItem);
+
+      assert.strictEqual(gtestsTreeView?.description, 'Regex: ^MathTest\\.');
+      assert.deepStrictEqual(cases.map((item: { label: string }) => item.label), ['Adds', 'Divides']);
+    } finally {
+      workflowModule.WorkflowManager.prototype.buildTarget = originalBuildTarget;
+      workflowModule.WorkflowManager.prototype.listGTestCases = originalListGTestCases;
+    }
   });
 
   it('runGTestCase runs visible filtered cases when invoked from a gtest target', async () => {
@@ -347,12 +466,9 @@ describe('extension commands', () => {
     };
     (vscode.window as any).showQuickPick = async (items: readonly { label: string; target?: unknown }[]) => {
       const quickPickItems = items as Array<{ label: string; target?: unknown }>;
-      if (quickPickItems.some((item) => item.target)) {
-        return quickPickItems.find((item) => item.label === 'app');
-      }
-
-      return quickPickItems.find((item) => item.label === 'MathTest');
+      return quickPickItems.find((item) => item.label === 'app');
     };
+    setQuickPickItemSelection('MathTest');
 
     try {
       await vscode.commands.executeCommand('cmakerunner.buildTargetFromCurrentFile');
@@ -391,13 +507,10 @@ describe('extension commands', () => {
 
     (vscode.window as any).showQuickPick = async (items: readonly { label: string; target?: unknown }[]) => {
       const quickPickItems = items as Array<{ label: string; target?: unknown }>;
-      if (quickPickItems.some((item) => item.target)) {
-        targetPickCount += 1;
-        return quickPickItems.find((item) => item.label === (targetPickCount === 1 ? 'app' : 'demo'));
-      }
-
-      return quickPickItems.find((item) => item.label === 'MathTest');
+      targetPickCount += 1;
+      return quickPickItems.find((item) => item.label === (targetPickCount === 1 ? 'app' : 'demo'));
     };
+    setQuickPickItemSelection('MathTest');
 
     try {
       await vscode.commands.executeCommand('cmakerunner.buildTargetFromCurrentFile');

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -182,6 +182,41 @@ describe('ui', () => {
       assert.strictEqual(provider.getVisibleTargetCount(), 1);
     });
 
+    it('should filter targets with a typed regular expression', async () => {
+      const provider = new TargetTreeDataProvider();
+      const targets: TargetInfo[] = [
+        {
+          id: 'myapp',
+          name: 'myapp',
+          displayName: 'My App',
+          sourceFiles: ['/src/app/main.cpp'],
+          guessedExecutablePath: '/build/myapp',
+        },
+        {
+          id: 'myservice',
+          name: 'myservice',
+          displayName: 'My Service',
+          sourceFiles: ['/src/service/main.cpp'],
+          guessedExecutablePath: '/build/myservice',
+        },
+        {
+          id: 'other',
+          name: 'other',
+          displayName: 'Other',
+          sourceFiles: ['/src/other.cpp'],
+          guessedExecutablePath: '/build/other',
+        },
+      ];
+
+      provider.setTargets(targets, '/src', undefined);
+      provider.setFilterText('^my(app|service)$', { isRegex: true });
+      const children = await provider.getChildren();
+
+      assert.strictEqual(provider.isFilterRegex(), true);
+      assert.strictEqual(provider.getVisibleTargetCount(), 2);
+      assert.deepStrictEqual(children.map((item) => item.label), ['My App', 'My Service']);
+    });
+
     it('should clear filter', () => {
       const provider = new TargetTreeDataProvider();
       const targets: TargetInfo[] = [
@@ -195,9 +230,10 @@ describe('ui', () => {
       ];
 
       provider.setTargets(targets, '/src', undefined);
-      provider.setFilterText('myapp');
+      provider.setFilterText('myapp', { isRegex: true });
       provider.setFilterText('');
       assert.strictEqual(provider.getVisibleTargetCount(), 1);
+      assert.strictEqual(provider.isFilterRegex(), false);
     });
 
     it('should find target item by id', () => {
@@ -456,6 +492,23 @@ describe('ui', () => {
       assert.strictEqual(await provider.getVisibleTargetCount(), 1);
     });
 
+    it('should filter gtest cases with a typed regular expression', async () => {
+      const provider = new GTestTreeDataProvider(async () => [
+        { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+        { suite: 'MathTest', name: 'Divides', filter: 'MathTest.Divides' },
+        { suite: 'StringTest', name: 'Splits', filter: 'StringTest.Splits' },
+      ]);
+      provider.setTargets([target]);
+      provider.setSelectedTarget(target, true);
+
+      provider.setFilterText('^MathTest\\.(Adds|Divides)$', { isRegex: true });
+      const [targetItem] = await provider.getChildren();
+      const cases = await provider.getChildren(targetItem);
+
+      assert.strictEqual(provider.isFilterRegex(), true);
+      assert.deepStrictEqual(cases.map((item) => item.label), ['Adds', 'Divides']);
+    });
+
     it('should expose visible gtest cases for filtered target runs', async () => {
       const provider = new GTestTreeDataProvider(async () => [
         { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
@@ -472,10 +525,11 @@ describe('ui', () => {
 
     it('should clear gtest filter text', () => {
       const provider = new GTestTreeDataProvider(async () => []);
-      provider.setFilterText('math');
+      provider.setFilterText('math', { isRegex: true });
       assert.strictEqual(provider.getFilterText(), 'math');
       provider.setFilterText('');
       assert.strictEqual(provider.getFilterText(), '');
+      assert.strictEqual(provider.isFilterRegex(), false);
     });
 
     it('should stay empty until a built target is selected', async () => {

--- a/test/vscode-mock.js
+++ b/test/vscode-mock.js
@@ -4,10 +4,12 @@ const path = require('path');
 const projectRoot = process.cwd();
 const registeredCommands = new Map();
 const createdTreeViews = new Map();
+let quickPickController;
 
 function resetMockState() {
   registeredCommands.clear();
   createdTreeViews.clear();
+  quickPickController = undefined;
   vscode.window.activeTextEditor = undefined;
 }
 
@@ -80,6 +82,51 @@ const vscode = {
     showErrorMessage: async (msg) => undefined,
     showQuickPick: async (items) => items?.[0],
     showInputBox: async () => undefined,
+    createQuickPick: () => {
+      const changeValueListeners = new Set();
+      const acceptListeners = new Set();
+      const hideListeners = new Set();
+      const quickPick = {
+        title: undefined,
+        value: '',
+        placeholder: undefined,
+        ignoreFocusOut: false,
+        matchOnDescription: false,
+        matchOnDetail: false,
+        items: [],
+        selectedItems: [],
+        activeItems: [],
+        onDidChangeValue: (listener) => {
+          changeValueListeners.add(listener);
+          return { dispose: () => changeValueListeners.delete(listener) };
+        },
+        onDidAccept: (listener) => {
+          acceptListeners.add(listener);
+          return { dispose: () => acceptListeners.delete(listener) };
+        },
+        onDidHide: (listener) => {
+          hideListeners.add(listener);
+          return { dispose: () => hideListeners.delete(listener) };
+        },
+        show: () => {
+          quickPickController?.(quickPick, {
+            changeValue: (value) => {
+              quickPick.value = value;
+              changeValueListeners.forEach((listener) => listener(value));
+            },
+            accept: () => {
+              acceptListeners.forEach((listener) => listener());
+            },
+            hide: () => {
+              hideListeners.forEach((listener) => listener());
+            },
+          });
+        },
+        hide: () => {},
+        dispose: () => {},
+      };
+      return quickPick;
+    },
     showTextDocument: async (document) => ({
       document,
       selection: undefined,
@@ -198,6 +245,9 @@ const vscode = {
   __mock: {
     registeredCommands,
     createdTreeViews,
+    setQuickPickController: (controller) => {
+      quickPickController = controller;
+    },
     reset: resetMockState,
   },
 };


### PR DESCRIPTION
## Summary
- add regex-aware filtering for Targets and GTests when users type a pattern and press Enter
- keep existing quick-pick item selection behavior for concrete targets, suites, and cases
- document the regex workflow and cover it with provider and extension command tests

## Tests
- npm test

Fixes #19