### PR TITLE
Continue GTest batches after failures

### DIFF
--- a/README-ALL.md
+++ b/README-ALL.md
@@ -117,7 +117,8 @@ Use `Filter` to choose from the current target, discovered suites, or discovered
 target names, executable names, suite names, case names, or full `suite.case` filters.
 You can also type a regular expression and press Enter to keep every matching GoogleTest visible.
 When a filter is active, the target-level `Run` action runs only the
-visible GoogleTest cases. Use `Clear Filter` to remove the filter, and `Refresh` to clear
+visible GoogleTest cases. Batch GoogleTest runs execute cases one by one, so later cases still run
+when an earlier case fails. Use `Clear Filter` to remove the filter, and `Refresh` to clear
 cached discovery results.
 
 ### 7. Filter targets

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Use `Filter` to choose from the current target, discovered suites, or discovered
 target names, executable names, suite names, case names, or full `suite.case` filters.
 You can also type a regular expression and press Enter to keep every matching GoogleTest visible.
 When a filter is active, the target-level `Run` action runs only the
-visible GoogleTest cases. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached discovery results.
+visible GoogleTest cases. Batch GoogleTest runs execute cases one by one, so later cases still run
+when an earlier case fails. Use `Clear Filter` to remove the filter, and `Refresh` to clear cached discovery results.
 
 
 ## Commands

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -113,7 +113,8 @@ code --install-extension cmakerunner-0.x.x.vsix
 使用 `Filter` 会展示当前目标、已发现的 suite 和已发现的 case，并可按目标名、
 可执行文件名、suite 名、case 名或完整 `suite.case` 过滤。过滤生效时，目标右侧的
 `Run` 操作只会运行当前可见的 GoogleTest 用例。你也可以直接输入正则表达式并回车，
-保留所有匹配的 GoogleTest；使用 `Clear Filter` 清除过滤；使用 `Refresh`
+保留所有匹配的 GoogleTest。批量运行 GoogleTest 时会逐个执行用例，因此前面的用例失败后，
+后续用例仍会继续运行；使用 `Clear Filter` 清除过滤；使用 `Refresh`
 清除已缓存的用例发现结果。
 
 ### 7. 过滤目标

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { GTestCaseInfo, PresetInfo, TargetInfo } from './models';
+import { GTestCaseInfo, GTestRunResult, PresetInfo, TargetInfo } from './models';
 import { ConfigurationManager } from './services/configurationManager';
 import { MappingEngine } from './services/mappingEngine';
 import { OutputLogger } from './services/outputLogger';
@@ -103,6 +103,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const applyGTestFilter = async (filterText: string, options?: { isRegex?: boolean }): Promise<void> => {
     gtestTreeDataProvider.setFilterText(filterText, options);
     await updateGTestViewState();
+  };
+
+  const recordGTestRunResult = (target: TargetInfo) => (result: GTestRunResult): void => {
+    gtestTreeDataProvider.recordRunResults(target, [result]);
   };
 
   let presets: PresetInfo[] = [];
@@ -761,7 +765,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
       if (item instanceof GTestCaseTreeItem) {
         await updateGTestSelection(item.target);
-        await workflowManager.runGTestCase(preset, item.target, true, item.testCase);
+        gtestTreeDataProvider.clearRunResults(item.target, [item.testCase]);
+        await workflowManager.runGTestCase(
+          preset,
+          item.target,
+          true,
+          item.testCase,
+          recordGTestRunResult(item.target),
+        );
         await updateGTestSelection(item.target);
         return;
       }
@@ -770,9 +781,22 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         await updateGTestSelection(item.target);
         if (gtestTreeDataProvider.getFilterText()) {
           const testCases = await gtestTreeDataProvider.getVisibleTestCases(item.target);
-          await workflowManager.runGTestCases(preset, item.target, testCases);
+          gtestTreeDataProvider.clearRunResults(item.target, testCases);
+          await workflowManager.runGTestCases(
+            preset,
+            item.target,
+            testCases,
+            true,
+            recordGTestRunResult(item.target),
+          );
         } else {
-          await workflowManager.runAllGTestCases(preset, item.target);
+          gtestTreeDataProvider.clearRunResults(item.target);
+          await workflowManager.runAllGTestCases(
+            preset,
+            item.target,
+            true,
+            recordGTestRunResult(item.target),
+          );
         }
         await updateGTestSelection(item.target);
         return;
@@ -784,7 +808,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       await selectTarget(target);
-      await workflowManager.runGTestCase(preset, target);
+      await workflowManager.runGTestCase(preset, target, true, undefined, recordGTestRunResult(target));
       await updateGTestSelection(target);
     }),
     vscode.commands.registerCommand('cmakerunner.debugGTestCase', async (item?: GTestCaseTreeItem) => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -23,6 +23,20 @@ export interface GTestCaseInfo {
   readonly filter: string;
 }
 
+export type GTestRunStatus = 'passed' | 'failed';
+
+export interface GTestRunResult {
+  readonly testCase: GTestCaseInfo;
+  readonly status: GTestRunStatus;
+  readonly exitCode: number;
+}
+
+export interface GTestRunSummary {
+  readonly target: TargetInfo;
+  readonly results: readonly GTestRunResult[];
+  readonly stopped?: boolean;
+}
+
 export interface MappingIndex {
   readonly targets: Map<string, TargetInfo>;
   readonly sourceToTargets: Map<string, string[]>;

--- a/src/services/taskExecutionEngine.ts
+++ b/src/services/taskExecutionEngine.ts
@@ -142,11 +142,11 @@ export class TaskExecutionEngine {
 
     if (process.platform === 'win32') {
       const escapedRunDirectory = runDirectory.replace(/'/g, "''");
-      return `Push-Location '${escapedRunDirectory}'; try { ${command} } finally { Pop-Location }`;
+      return `Push-Location '${escapedRunDirectory}'; try { ${command}; $cmakerunnerExitCode = if ($LASTEXITCODE -is [int]) { $LASTEXITCODE } elseif ($?) { 0 } else { 1 } } finally { Pop-Location }; exit $cmakerunnerExitCode`;
     }
 
     const escapedRunDirectory = runDirectory.replace(/'/g, `'\\''`);
-    return `__cmakerunner_oldpwd="$PWD"; cd '${escapedRunDirectory}' && ${command}; cd "$__cmakerunner_oldpwd"`;
+    return `__cmakerunner_oldpwd="$PWD"; cd '${escapedRunDirectory}' && { ${command}; __cmakerunner_status=$?; cd "$__cmakerunner_oldpwd"; exit $__cmakerunner_status; }`;
   }
 }
 

--- a/src/services/workflowManager.ts
+++ b/src/services/workflowManager.ts
@@ -7,6 +7,11 @@ import { ConfigurationManager } from './configurationManager';
 import { OutputLogger } from './outputLogger';
 import { TaskExecutionEngine } from './taskExecutionEngine';
 
+interface GTestRunFailure {
+  readonly filter: string;
+  readonly exitCode: number;
+}
+
 export class WorkflowManager {
   public constructor(
     private readonly configurationManager: ConfigurationManager,
@@ -130,8 +135,8 @@ export class WorkflowManager {
     testCases: readonly GTestCaseInfo[],
     buildFirst = true,
   ): Promise<void> {
-    const filters = Array.from(new Set(testCases.map((testCase) => testCase.filter).filter(Boolean)));
-    if (filters.length === 0) {
+    const uniqueTestCases = this.getUniqueGTestCases(testCases);
+    if (uniqueTestCases.length === 0) {
       void vscode.window.showWarningMessage(`No GoogleTest cases were selected in ${target.displayName}.`);
       return;
     }
@@ -150,14 +155,7 @@ export class WorkflowManager {
       }
     }
 
-    const runVariables = this.createVariables(preset, target);
-    const gtestFilterArgument = `--gtest_filter=${quoteForShell(filters.join(':'))}`;
-    const runCommand = `${this.configurationManager.getRunCommand(runVariables)} ${gtestFilterArgument}`;
-    const runLabel = filters.length === 1
-      ? `Run ${filters[0]} [${preset.name}]`
-      : `Run ${filters.length} GoogleTest cases in ${target.displayName} [${preset.name}]`;
-    this.logger.info(`Launching ${filters.length} filtered GoogleTest case(s) for target ${target.name}`);
-    await this.taskExecutionEngine.executeRun(runCommand, runLabel, preset.binaryDir);
+    await this.runGTestCasesSequentially(preset, target, uniqueTestCases);
   }
 
   public async runAllGTestCases(
@@ -189,11 +187,7 @@ export class WorkflowManager {
       return;
     }
 
-    const runVariables = this.createVariables(preset, target);
-    const runCommand = this.configurationManager.getRunCommand(runVariables);
-    const runLabel = `Run all tests in ${target.displayName} [${preset.name}]`;
-    this.logger.info(`Launching all GoogleTest cases for target ${target.name}`);
-    await this.taskExecutionEngine.executeRun(runCommand, runLabel, preset.binaryDir);
+    await this.runGTestCasesSequentially(preset, target, testCases);
   }
 
   public async debugGTestCase(
@@ -363,6 +357,67 @@ export class WorkflowManager {
         Buffer.from(JSON.stringify({ version: '0.2.0', configurations: [] }, null, 2)),
       );
     }
+  }
+
+  private async runGTestCasesSequentially(
+    preset: PresetInfo,
+    target: TargetInfo,
+    testCases: readonly GTestCaseInfo[],
+  ): Promise<void> {
+    const uniqueTestCases = this.getUniqueGTestCases(testCases);
+    const runVariables = this.createVariables(preset, target);
+    const baseRunCommand = this.configurationManager.getRunCommand(runVariables);
+    const failures: GTestRunFailure[] = [];
+
+    for (let index = 0; index < uniqueTestCases.length; index += 1) {
+      const testCase = uniqueTestCases[index];
+      const gtestFilterArgument = `--gtest_filter=${quoteForShell(testCase.filter)}`;
+      const runCommand = `${baseRunCommand} ${gtestFilterArgument}`;
+      const runLabel = uniqueTestCases.length === 1
+        ? `Run ${testCase.filter} [${preset.name}]`
+        : `Run ${testCase.filter} (${index + 1}/${uniqueTestCases.length}) [${preset.name}]`;
+
+      this.logger.info(`Launching GoogleTest case ${testCase.filter} (${index + 1}/${uniqueTestCases.length}) for target ${target.name}`);
+      const result = await this.taskExecutionEngine.executeRun(runCommand, runLabel, preset.binaryDir);
+      if (typeof result.exitCode !== 'number') {
+        this.logger.warn(`GoogleTest run stopped after ${testCase.filter} because no exit code was reported.`);
+        void vscode.window.showWarningMessage(`GoogleTest run stopped after ${testCase.filter}; no exit code was reported.`);
+        return;
+      }
+
+      if (result.exitCode !== 0) {
+        failures.push({ filter: testCase.filter, exitCode: result.exitCode });
+        this.logger.warn(`GoogleTest case ${testCase.filter} failed with exit code ${result.exitCode}; continuing with remaining cases.`);
+      }
+    }
+
+    this.reportGTestRunFailures(target, failures, uniqueTestCases.length);
+  }
+
+  private getUniqueGTestCases(testCases: readonly GTestCaseInfo[]): GTestCaseInfo[] {
+    const seen = new Set<string>();
+    const uniqueTestCases: GTestCaseInfo[] = [];
+
+    for (const testCase of testCases) {
+      if (!testCase.filter || seen.has(testCase.filter)) {
+        continue;
+      }
+
+      seen.add(testCase.filter);
+      uniqueTestCases.push(testCase);
+    }
+
+    return uniqueTestCases;
+  }
+
+  private reportGTestRunFailures(target: TargetInfo, failures: readonly GTestRunFailure[], totalCount: number): void {
+    if (failures.length === 0) {
+      return;
+    }
+
+    const failureDetails = failures.map((failure) => `${failure.filter} (exit code ${failure.exitCode})`).join(', ');
+    this.logger.error(`${failures.length} of ${totalCount} GoogleTest case(s) failed in ${target.name}: ${failureDetails}`);
+    void vscode.window.showErrorMessage(`${failures.length} of ${totalCount} GoogleTest cases failed in ${target.displayName}. Check the terminal output for details.`);
   }
 
   public async listGTestCases(preset: PresetInfo, target: TargetInfo): Promise<GTestCaseInfo[] | undefined> {

--- a/src/services/workflowManager.ts
+++ b/src/services/workflowManager.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { execFile } from 'child_process';
 import * as vscode from 'vscode';
-import { GTestCaseInfo, PresetInfo, TargetInfo } from '../models';
+import { GTestCaseInfo, GTestRunResult, GTestRunSummary, PresetInfo, TargetInfo } from '../models';
 import { quoteForShell } from '../utils';
 import { ConfigurationManager } from './configurationManager';
 import { OutputLogger } from './outputLogger';
@@ -91,7 +91,8 @@ export class WorkflowManager {
     target: TargetInfo,
     buildFirst = true,
     selectedTestCase?: GTestCaseInfo,
-  ): Promise<void> {
+    onCaseResult?: (result: GTestRunResult) => void,
+  ): Promise<GTestRunSummary | undefined> {
     if (buildFirst) {
       const buildVariables = this.createVariables(preset, target);
       const built = await this.executeBuildStep({
@@ -102,23 +103,23 @@ export class WorkflowManager {
         failureVerb: 'Build',
       });
       if (!built) {
-        return;
+        return undefined;
       }
     }
 
     const testCases = selectedTestCase ? [selectedTestCase] : await this.listGTestCases(preset, target);
     if (!testCases) {
-      return;
+      return undefined;
     }
 
     if (!selectedTestCase && testCases.length === 0) {
       void vscode.window.showWarningMessage(`No GoogleTest cases were found in ${target.displayName}.`);
-      return;
+      return undefined;
     }
 
     const testCase = selectedTestCase ?? await this.pickGTestCase(testCases);
     if (!testCase) {
-      return;
+      return undefined;
     }
 
     const runVariables = this.createVariables(preset, target);
@@ -126,7 +127,16 @@ export class WorkflowManager {
     const runCommand = `${this.configurationManager.getRunCommand(runVariables)} ${gtestFilterArgument}`;
     const runLabel = `Run ${testCase.filter} [${preset.name}]`;
     this.logger.info(`Launching GoogleTest case ${testCase.filter} for target ${target.name}`);
-    await this.taskExecutionEngine.executeRun(runCommand, runLabel, preset.binaryDir);
+    const result = await this.taskExecutionEngine.executeRun(runCommand, runLabel, preset.binaryDir);
+    if (typeof result.exitCode !== 'number') {
+      this.logger.warn(`GoogleTest run stopped after ${testCase.filter} because no exit code was reported.`);
+      void vscode.window.showWarningMessage(`GoogleTest run stopped after ${testCase.filter}; no exit code was reported.`);
+      return { target, results: [], stopped: true };
+    }
+
+    const runResult = this.createGTestRunResult(testCase, result.exitCode);
+    onCaseResult?.(runResult);
+    return { target, results: [runResult] };
   }
 
   public async runGTestCases(
@@ -134,11 +144,12 @@ export class WorkflowManager {
     target: TargetInfo,
     testCases: readonly GTestCaseInfo[],
     buildFirst = true,
-  ): Promise<void> {
+    onCaseResult?: (result: GTestRunResult) => void,
+  ): Promise<GTestRunSummary | undefined> {
     const uniqueTestCases = this.getUniqueGTestCases(testCases);
     if (uniqueTestCases.length === 0) {
       void vscode.window.showWarningMessage(`No GoogleTest cases were selected in ${target.displayName}.`);
-      return;
+      return undefined;
     }
 
     if (buildFirst) {
@@ -151,18 +162,19 @@ export class WorkflowManager {
         failureVerb: 'Build',
       });
       if (!built) {
-        return;
+        return undefined;
       }
     }
 
-    await this.runGTestCasesSequentially(preset, target, uniqueTestCases);
+    return this.runGTestCasesSequentially(preset, target, uniqueTestCases, onCaseResult);
   }
 
   public async runAllGTestCases(
     preset: PresetInfo,
     target: TargetInfo,
     buildFirst = true,
-  ): Promise<void> {
+    onCaseResult?: (result: GTestRunResult) => void,
+  ): Promise<GTestRunSummary | undefined> {
     if (buildFirst) {
       const buildVariables = this.createVariables(preset, target);
       const built = await this.executeBuildStep({
@@ -173,21 +185,21 @@ export class WorkflowManager {
         failureVerb: 'Build',
       });
       if (!built) {
-        return;
+        return undefined;
       }
     }
 
     const testCases = await this.listGTestCases(preset, target);
     if (!testCases) {
-      return;
+      return undefined;
     }
 
     if (testCases.length === 0) {
       void vscode.window.showWarningMessage(`No GoogleTest cases were found in ${target.displayName}.`);
-      return;
+      return undefined;
     }
 
-    await this.runGTestCasesSequentially(preset, target, testCases);
+    return this.runGTestCasesSequentially(preset, target, testCases, onCaseResult);
   }
 
   public async debugGTestCase(
@@ -363,11 +375,13 @@ export class WorkflowManager {
     preset: PresetInfo,
     target: TargetInfo,
     testCases: readonly GTestCaseInfo[],
-  ): Promise<void> {
+    onCaseResult?: (result: GTestRunResult) => void,
+  ): Promise<GTestRunSummary> {
     const uniqueTestCases = this.getUniqueGTestCases(testCases);
     const runVariables = this.createVariables(preset, target);
     const baseRunCommand = this.configurationManager.getRunCommand(runVariables);
     const failures: GTestRunFailure[] = [];
+    const results: GTestRunResult[] = [];
 
     for (let index = 0; index < uniqueTestCases.length; index += 1) {
       const testCase = uniqueTestCases[index];
@@ -382,8 +396,12 @@ export class WorkflowManager {
       if (typeof result.exitCode !== 'number') {
         this.logger.warn(`GoogleTest run stopped after ${testCase.filter} because no exit code was reported.`);
         void vscode.window.showWarningMessage(`GoogleTest run stopped after ${testCase.filter}; no exit code was reported.`);
-        return;
+        return { target, results, stopped: true };
       }
+
+      const runResult = this.createGTestRunResult(testCase, result.exitCode);
+      results.push(runResult);
+      onCaseResult?.(runResult);
 
       if (result.exitCode !== 0) {
         failures.push({ filter: testCase.filter, exitCode: result.exitCode });
@@ -392,6 +410,15 @@ export class WorkflowManager {
     }
 
     this.reportGTestRunFailures(target, failures, uniqueTestCases.length);
+    return { target, results };
+  }
+
+  private createGTestRunResult(testCase: GTestCaseInfo, exitCode: number): GTestRunResult {
+    return {
+      testCase,
+      exitCode,
+      status: exitCode === 0 ? 'passed' : 'failed',
+    };
   }
 
   private getUniqueGTestCases(testCases: readonly GTestCaseInfo[]): GTestCaseInfo[] {

--- a/src/ui/gtestTreeDataProvider.ts
+++ b/src/ui/gtestTreeDataProvider.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { GTestCaseInfo, TargetInfo } from '../models';
+import { GTestCaseInfo, GTestRunResult, GTestRunStatus, TargetInfo } from '../models';
 import { normalizePath } from '../utils';
 import { FilterMatcher, createFilterMatcher } from './filterMatcher';
 
@@ -18,18 +18,31 @@ export class GTestCaseTreeItem extends vscode.TreeItem {
   public constructor(
     public readonly target: TargetInfo,
     public readonly testCase: GTestCaseInfo,
+    public readonly runStatus?: GTestRunStatus,
   ) {
     super(testCase.name, vscode.TreeItemCollapsibleState.None);
     this.description = testCase.suite;
-    this.tooltip = testCase.filter;
+    this.tooltip = runStatus ? `${testCase.filter}\nLast run: ${runStatus}` : testCase.filter;
     this.contextValue = 'gtestCase';
-    this.iconPath = new vscode.ThemeIcon('testing-passed-icon');
+    this.iconPath = getGTestCaseIcon(runStatus);
     this.command = {
       command: 'cmakerunner.openGTestCaseSource',
       title: 'Open GTest Source',
       arguments: [this],
     };
   }
+}
+
+function getGTestCaseIcon(runStatus: GTestRunStatus | undefined): vscode.ThemeIcon {
+  if (runStatus === 'passed') {
+    return new vscode.ThemeIcon('testing-passed-icon');
+  }
+
+  if (runStatus === 'failed') {
+    return new vscode.ThemeIcon('testing-failed-icon');
+  }
+
+  return new vscode.ThemeIcon('testing-unset-icon');
 }
 
 type Node = GTestTargetTreeItem | GTestCaseTreeItem;
@@ -39,6 +52,7 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
   private targets: TargetInfo[] = [];
   private targetItems = new Map<string, GTestTargetTreeItem>();
   private testCasesByTargetId = new Map<string, GTestCaseInfo[]>();
+  private runStatusByTargetId = new Map<string, Map<string, GTestRunStatus>>();
   private filterText = '';
   private filterIsRegex = false;
   private selectedTargetId?: string;
@@ -57,6 +71,7 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
       this.selectedTargetBuilt = false;
     }
     this.testCasesByTargetId.clear();
+    this.removeRunResultsForMissingTargets(targets);
     this.targetItems = new Map(targets.map((target) => [target.id, new GTestTargetTreeItem(target)]));
     this.onDidChangeTreeDataEmitter.fire();
   }
@@ -75,6 +90,42 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
 
   public refresh(): void {
     this.testCasesByTargetId.clear();
+    this.onDidChangeTreeDataEmitter.fire();
+  }
+
+  public clearRunResults(target: TargetInfo, testCases?: readonly GTestCaseInfo[]): void {
+    const targetResults = this.runStatusByTargetId.get(target.id);
+    if (!targetResults) {
+      return;
+    }
+
+    if (!testCases) {
+      this.runStatusByTargetId.delete(target.id);
+      this.onDidChangeTreeDataEmitter.fire();
+      return;
+    }
+
+    for (const testCase of testCases) {
+      targetResults.delete(testCase.filter);
+    }
+
+    if (targetResults.size === 0) {
+      this.runStatusByTargetId.delete(target.id);
+    }
+
+    this.onDidChangeTreeDataEmitter.fire();
+  }
+
+  public recordRunResults(target: TargetInfo, results: readonly GTestRunResult[]): void {
+    if (results.length === 0) {
+      return;
+    }
+
+    const targetResults = this.getOrCreateRunResults(target.id);
+    for (const result of results) {
+      targetResults.set(result.testCase.filter, result.status);
+    }
+
     this.onDidChangeTreeDataEmitter.fire();
   }
 
@@ -130,7 +181,11 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
     if (element instanceof GTestTargetTreeItem) {
       const testCases = await this.getVisibleTestCases(element.target);
       return testCases
-        .map((testCase) => new GTestCaseTreeItem(element.target, testCase));
+        .map((testCase) => new GTestCaseTreeItem(
+          element.target,
+          testCase,
+          this.getRunStatus(element.target, testCase),
+        ));
     }
 
     return [];
@@ -153,6 +208,30 @@ export class GTestTreeDataProvider implements vscode.TreeDataProvider<Node> {
     const cachedTestCases = testCases ?? [];
     this.testCasesByTargetId.set(target.id, cachedTestCases);
     return cachedTestCases;
+  }
+
+  private getOrCreateRunResults(targetId: string): Map<string, GTestRunStatus> {
+    const existingResults = this.runStatusByTargetId.get(targetId);
+    if (existingResults) {
+      return existingResults;
+    }
+
+    const nextResults = new Map<string, GTestRunStatus>();
+    this.runStatusByTargetId.set(targetId, nextResults);
+    return nextResults;
+  }
+
+  private getRunStatus(target: TargetInfo, testCase: GTestCaseInfo): GTestRunStatus | undefined {
+    return this.runStatusByTargetId.get(target.id)?.get(testCase.filter);
+  }
+
+  private removeRunResultsForMissingTargets(targets: readonly TargetInfo[]): void {
+    const targetIds = new Set(targets.map((target) => target.id));
+    for (const targetId of this.runStatusByTargetId.keys()) {
+      if (!targetIds.has(targetId)) {
+        this.runStatusByTargetId.delete(targetId);
+      }
+    }
   }
 
   private async getVisibleTargets(): Promise<TargetInfo[]> {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -274,6 +274,7 @@ describe('extension commands', () => {
     const originalRunGTestCase = workflowModule.WorkflowManager.prototype.runGTestCase;
     workflowModule.WorkflowManager.prototype.runGTestCase = async (_preset, target) => {
       gtestTargetName = target.name;
+      return undefined;
     };
 
     try {
@@ -460,9 +461,11 @@ describe('extension commands', () => {
     ];
     workflowModule.WorkflowManager.prototype.runGTestCases = async (_preset, _target, testCases) => {
       filters = testCases.map((testCase) => testCase.filter);
+      return undefined;
     };
     workflowModule.WorkflowManager.prototype.runAllGTestCases = async () => {
       ranAll = true;
+      return undefined;
     };
     (vscode.window as any).showQuickPick = async (items: readonly { label: string; target?: unknown }[]) => {
       const quickPickItems = items as Array<{ label: string; target?: unknown }>;

--- a/test/taskExecutionEngine.test.ts
+++ b/test/taskExecutionEngine.test.ts
@@ -110,6 +110,48 @@ describe('task execution engine', () => {
       assert.deepStrictEqual(capturedTask?.problemMatchers, []);
       assert.ok(String((capturedTask?.execution as any)?.command).includes("Push-Location 'C:/work dir'"));
       assert.ok(String((capturedTask?.execution as any)?.command).includes('& "C:/tools/my app.exe"'));
+      assert.ok(String((capturedTask?.execution as any)?.command).includes('exit $cmakerunnerExitCode'));
+    } finally {
+      restorePlatform();
+      (vscode.tasks as any).executeTask = originalExecuteTask;
+      (vscode.tasks as any).onDidEndTaskProcess = originalOnDidEndTaskProcess;
+      (vscode.tasks as any).onDidEndTask = originalOnDidEndTask;
+    }
+  });
+
+  it('executeRun preserves non-Windows run command exit codes when wrapping the working directory', async () => {
+    const restorePlatform = setPlatform('darwin');
+    const originalExecuteTask = vscode.tasks.executeTask;
+    const originalOnDidEndTaskProcess = vscode.tasks.onDidEndTaskProcess;
+    const originalOnDidEndTask = vscode.tasks.onDidEndTask;
+
+    const execution = { id: 'run-execution' };
+    let capturedTask: vscode.Task | undefined;
+    let processListener: ((event: { execution: unknown; exitCode: number | undefined }) => void) | undefined;
+
+    (vscode.tasks as any).executeTask = async (task: vscode.Task) => {
+      capturedTask = task;
+      return execution;
+    };
+    (vscode.tasks as any).onDidEndTaskProcess = (listener: typeof processListener) => {
+      processListener = listener;
+      return { dispose: () => {} };
+    };
+    (vscode.tasks as any).onDidEndTask = () => ({ dispose: () => {} });
+
+    try {
+      const engine = createEngine();
+      const resultPromise = engine.executeRun('/tmp/build/app --gtest_filter=Suite.Test', 'Run Suite.Test', '/tmp/build dir');
+      await Promise.resolve();
+      processListener?.({ execution, exitCode: 1 });
+      const result = await resultPromise;
+
+      assert.strictEqual(result.exitCode, 1);
+      assert.ok(capturedTask);
+      const command = String((capturedTask?.execution as any)?.command);
+      assert.ok(command.includes("__cmakerunner_oldpwd=\"$PWD\"; cd '/tmp/build dir'"));
+      assert.ok(command.includes('__cmakerunner_status=$?'));
+      assert.ok(command.includes('exit $__cmakerunner_status'));
     } finally {
       restorePlatform();
       (vscode.tasks as any).executeTask = originalExecuteTask;

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -433,6 +433,38 @@ describe('ui', () => {
       assert.ok(cases[0] instanceof GTestCaseTreeItem);
       assert.strictEqual(cases[0].contextValue, 'gtestCase');
       assert.strictEqual(cases[0].command?.command, 'cmakerunner.openGTestCaseSource');
+      assert.strictEqual((cases[0].iconPath as any).id, 'testing-unset-icon');
+    });
+
+    it('should record gtest run results and show pass/fail icons', async () => {
+      const provider = new GTestTreeDataProvider(async () => [
+        { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' },
+        { suite: 'MathTest', name: 'Divides', filter: 'MathTest.Divides' },
+        { suite: 'StringTest', name: 'Splits', filter: 'StringTest.Splits' },
+      ]);
+      provider.setTargets([target]);
+      provider.setSelectedTarget(target, true);
+
+      provider.recordRunResults(target, [
+        { testCase: { suite: 'MathTest', name: 'Adds', filter: 'MathTest.Adds' }, status: 'passed', exitCode: 0 },
+        { testCase: { suite: 'MathTest', name: 'Divides', filter: 'MathTest.Divides' }, status: 'failed', exitCode: 1 },
+      ]);
+      const [targetItem] = await provider.getChildren();
+      const cases = await provider.getChildren(targetItem);
+
+      assert.deepStrictEqual(cases.map((item) => (item.iconPath as any).id), [
+        'testing-passed-icon',
+        'testing-failed-icon',
+        'testing-unset-icon',
+      ]);
+
+      provider.clearRunResults(target, [{ suite: 'MathTest', name: 'Divides', filter: 'MathTest.Divides' }]);
+      const updatedCases = await provider.getChildren(targetItem);
+      assert.deepStrictEqual(updatedCases.map((item) => (item.iconPath as any).id), [
+        'testing-passed-icon',
+        'testing-unset-icon',
+        'testing-unset-icon',
+      ]);
     });
 
     it('should cache discovered cases until refresh', async () => {

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -367,16 +367,29 @@ describe('workflow manager', () => {
 
     try {
       const manager = new WorkflowManager(deps.configurationManager as never, deps.taskExecutionEngine as never, deps.logger as never);
-      await manager.runGTestCases(preset, target, [
+      const streamedResults: string[] = [];
+      const result = await manager.runGTestCases(preset, target, [
         { suite: 'SuiteA', name: 'TestOne', filter: 'SuiteA.TestOne' },
         { suite: 'SuiteA', name: 'TestTwo', filter: 'SuiteA.TestTwo' },
         { suite: 'SuiteA', name: 'TestThree', filter: 'SuiteA.TestThree' },
-      ], false);
+      ], false, (runResult) => {
+        streamedResults.push(`${runResult.testCase.filter}:${runResult.status}:${runResult.exitCode}`);
+      });
 
       assert.deepStrictEqual(runCommands, [
         '/tmp/build/debug/app --gtest_filter=SuiteA.TestOne',
         '/tmp/build/debug/app --gtest_filter=SuiteA.TestTwo',
         '/tmp/build/debug/app --gtest_filter=SuiteA.TestThree',
+      ]);
+      assert.deepStrictEqual(result?.results.map((runResult) => `${runResult.testCase.filter}:${runResult.status}`), [
+        'SuiteA.TestOne:failed',
+        'SuiteA.TestTwo:passed',
+        'SuiteA.TestThree:failed',
+      ]);
+      assert.deepStrictEqual(streamedResults, [
+        'SuiteA.TestOne:failed:1',
+        'SuiteA.TestTwo:passed:0',
+        'SuiteA.TestThree:failed:2',
       ]);
       assert.ok(shown.includes('2 of 3 GoogleTest cases failed'));
       assert.ok(deps.calls.some((call) => call.includes('continuing with remaining cases')));

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -323,13 +323,13 @@ describe('workflow manager', () => {
     }
   });
 
-  it('runGTestCases runs selected cases with a combined filter', async () => {
+  it('runGTestCases runs selected cases separately', async () => {
     const deps = createDeps();
-    let runCommand = '';
-    let runLabel = '';
+    const runCommands: string[] = [];
+    const runLabels: string[] = [];
     deps.taskExecutionEngine.executeRun = async (command?: string, label?: string) => {
-      runCommand = command ?? '';
-      runLabel = label ?? '';
+      runCommands.push(command ?? '');
+      runLabels.push(label ?? '');
       return { exitCode: 0 };
     };
 
@@ -339,8 +339,50 @@ describe('workflow manager', () => {
       { suite: 'SuiteA', name: 'TestTwo', filter: 'SuiteA.TestTwo' },
     ], false);
 
-    assert.strictEqual(runCommand, '/tmp/build/debug/app --gtest_filter=SuiteA.TestOne:SuiteA.TestTwo');
-    assert.strictEqual(runLabel, 'Run 2 GoogleTest cases in App [debug]');
+    assert.deepStrictEqual(runCommands, [
+      '/tmp/build/debug/app --gtest_filter=SuiteA.TestOne',
+      '/tmp/build/debug/app --gtest_filter=SuiteA.TestTwo',
+    ]);
+    assert.deepStrictEqual(runLabels, [
+      'Run SuiteA.TestOne (1/2) [debug]',
+      'Run SuiteA.TestTwo (2/2) [debug]',
+    ]);
+  });
+
+  it('runGTestCases continues remaining cases after failures', async () => {
+    const deps = createDeps();
+    const runCommands: string[] = [];
+    const exitCodes = [1, 0, 2];
+    deps.taskExecutionEngine.executeRun = async (command?: string) => {
+      runCommands.push(command ?? '');
+      return { exitCode: exitCodes.shift() ?? 0 };
+    };
+
+    let shown = '';
+    const originalShowErrorMessage = vscode.window.showErrorMessage;
+    (vscode.window as any).showErrorMessage = async (message: string) => {
+      shown = message;
+      return undefined;
+    };
+
+    try {
+      const manager = new WorkflowManager(deps.configurationManager as never, deps.taskExecutionEngine as never, deps.logger as never);
+      await manager.runGTestCases(preset, target, [
+        { suite: 'SuiteA', name: 'TestOne', filter: 'SuiteA.TestOne' },
+        { suite: 'SuiteA', name: 'TestTwo', filter: 'SuiteA.TestTwo' },
+        { suite: 'SuiteA', name: 'TestThree', filter: 'SuiteA.TestThree' },
+      ], false);
+
+      assert.deepStrictEqual(runCommands, [
+        '/tmp/build/debug/app --gtest_filter=SuiteA.TestOne',
+        '/tmp/build/debug/app --gtest_filter=SuiteA.TestTwo',
+        '/tmp/build/debug/app --gtest_filter=SuiteA.TestThree',
+      ]);
+      assert.ok(shown.includes('2 of 3 GoogleTest cases failed'));
+      assert.ok(deps.calls.some((call) => call.includes('continuing with remaining cases')));
+    } finally {
+      (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+    }
   });
 
   it('runGTestCases does not run when no cases are selected', async () => {
@@ -368,11 +410,11 @@ describe('workflow manager', () => {
     }
   });
 
-  it('runAllGTestCases runs the target executable without a gtest filter', async () => {
+  it('runAllGTestCases runs discovered cases separately', async () => {
     const deps = createDeps();
-    let runCommand = '';
+    const runCommands: string[] = [];
     deps.taskExecutionEngine.executeRun = async (command?: string) => {
-      runCommand = command ?? '';
+      runCommands.push(command ?? '');
       return { exitCode: 0 };
     };
 
@@ -385,9 +427,48 @@ describe('workflow manager', () => {
     try {
       const manager = new WorkflowManager(deps.configurationManager as never, deps.taskExecutionEngine as never, deps.logger as never);
       await manager.runAllGTestCases(preset, target, false);
-      assert.strictEqual(runCommand, '/tmp/build/debug/app');
+      assert.deepStrictEqual(runCommands, [
+        '/tmp/build/debug/app --gtest_filter=SuiteA.TestOne',
+        '/tmp/build/debug/app --gtest_filter=SuiteA.TestTwo',
+      ]);
     } finally {
       (childProcess as any).execFile = originalExecFile;
+    }
+  });
+
+  it('runAllGTestCases continues after a discovered case fails', async () => {
+    const deps = createDeps();
+    const runCommands: string[] = [];
+    const exitCodes = [0, 1, 0];
+    deps.taskExecutionEngine.executeRun = async (command?: string) => {
+      runCommands.push(command ?? '');
+      return { exitCode: exitCodes.shift() ?? 0 };
+    };
+
+    const originalExecFile = childProcess.execFile;
+    const originalShowErrorMessage = vscode.window.showErrorMessage;
+    let shown = '';
+    (childProcess as any).execFile = (_file: string, _args: string[], _options: unknown, callback: Function) => {
+      callback(undefined, 'SuiteA.\n  TestOne\n  TestTwo\n  TestThree\n', '');
+      return {} as ChildProcess;
+    };
+    (vscode.window as any).showErrorMessage = async (message: string) => {
+      shown = message;
+      return undefined;
+    };
+
+    try {
+      const manager = new WorkflowManager(deps.configurationManager as never, deps.taskExecutionEngine as never, deps.logger as never);
+      await manager.runAllGTestCases(preset, target, false);
+      assert.deepStrictEqual(runCommands, [
+        '/tmp/build/debug/app --gtest_filter=SuiteA.TestOne',
+        '/tmp/build/debug/app --gtest_filter=SuiteA.TestTwo',
+        '/tmp/build/debug/app --gtest_filter=SuiteA.TestThree',
+      ]);
+      assert.ok(shown.includes('1 of 3 GoogleTest cases failed'));
+    } finally {
+      (childProcess as any).execFile = originalExecFile;
+      (vscode.window as any).showErrorMessage = originalShowErrorMessage;
     }
   });
 


### PR DESCRIPTION
## Summary
- run selected/all GoogleTest cases one by one instead of combining them into a single gtest run
- continue running remaining cases after a case exits non-zero, then report a failure summary
- document the batch-run behavior and add workflow tests for continuing after failures

## Tests
- npm test

Fixes #21