### PR TITLE
Support SHARED_LIBRARY and UTILITY targets; restrict run/debug to EXECUTABLE and show warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CMake Runner
 
+## V0.3.4 2026-05-28
+### Enhancements
+* Expand mapped target types to `EXECUTABLE`, `SHARED_LIBRARY`, and `UTILITY`
+* Keep run/debug/GoogleTest commands executable-only and show warnings for non-runnable target types
+
 ## V0.3.3 2026-05-26
 ### Enhancements
 Continue running remaining GTest cases after failures

--- a/README-ALL.md
+++ b/README-ALL.md
@@ -2,9 +2,9 @@
 
 English documentation is the default in this file. For the Chinese version, see `doc/README.zh-CN.md`.
 
-`CMake Runner` is a VS Code extension for CMake-based C++ projects. It puts the common workflow of **select preset -> configure -> discover executable targets -> build -> run/debug** into a dedicated sidebar.
+`CMake Runner` is a VS Code extension for CMake-based C++ projects. It puts the common workflow of **select preset -> configure -> discover targets -> build -> run/debug** into a dedicated sidebar.
 
-It is designed for projects that already use `CMakePresets.json` and want a more direct way to work from the current source file back to the executable target that owns it.
+It is designed for projects that already use `CMakePresets.json` and want a more direct way to work from the current source file back to the target that owns it.
 
 Implementation and architecture notes are available in `doc/architecture.zh-CN.md`.
 
@@ -16,8 +16,8 @@ Implementation and architecture notes are available in `doc/architecture.zh-CN.m
 - Associates configure presets with matching CMake build presets when available
 - Runs preset configure directly from VS Code tasks
 - Writes the CMake File API `codemodel-v2` query before configure
-- Discovers executable targets from `<binaryDir>/.cmake/api/v1/reply/`
-- Builds a source file to executable target mapping from the CMake codemodel
+- Discovers supported targets (`EXECUTABLE`, `SHARED_LIBRARY`, `UTILITY`) from `<binaryDir>/.cmake/api/v1/reply/`
+- Builds a source file to target mapping from the CMake codemodel
 - Reveals the matching source node when the active editor switches to a mapped file
 - Supports target filtering by target name, executable name, or source file name
 - Builds, runs, and debugs targets from the `Targets` view or from the active mapped source file
@@ -30,7 +30,7 @@ Implementation and architecture notes are available in `doc/architecture.zh-CN.m
 The extension revolves around three activity bar views:
 
 - `Presets`: choose the active CMake configure preset
-- `Targets`: inspect discovered executable targets and their source files
+- `Targets`: inspect discovered supported targets and their source files
 - `GTests`: inspect and run GoogleTest cases by executable target
 
 Typical usage looks like this:
@@ -39,7 +39,7 @@ Typical usage looks like this:
 2. Select a configure preset in `Presets`
 3. Run `Build` on that preset to configure the project
 4. The extension reads the CMake File API reply data from the preset's build directory
-5. Discovered executable targets appear in `Targets`
+5. Discovered supported targets appear in `Targets`
 6. Build, run, or debug a target from the tree
 7. When you open a mapped source file, the extension reveals the corresponding source entry in the tree
 
@@ -91,7 +91,7 @@ Run `Build` on the selected preset. The extension configures the project and rea
 <binaryDir>/.cmake/api/v1/reply/
 ```
 
-If configure succeeds and CMake generated the File API reply, executable targets appear in **Targets**.
+If configure succeeds and CMake generated the File API reply, supported targets (`EXECUTABLE`, `SHARED_LIBRARY`, `UTILITY`) appear in **Targets**.
 
 ### 4. Build a target
 
@@ -106,7 +106,7 @@ You can invoke these actions directly on a target:
 - `Run`
 - `Debug`
 
-By default, both actions build the target first.
+By default, both actions build the target first. `Run` and `Debug` only support `EXECUTABLE` targets; non-runnable target types show a warning.
 
 ### 6. Run one GoogleTest case
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CMake Runner
 
-`CMake Runner` is a VS Code extension for CMake-based C++ projects. It puts the common workflow of **select preset -> configure -> discover executable targets -> build -> run/debug** into a dedicated sidebar.
+`CMake Runner` is a VS Code extension for CMake-based C++ projects. It puts the common workflow of **select preset -> configure -> discover targets -> build -> run/debug** into a dedicated sidebar.
 
 It is designed for projects that already use `CMakePresets.json` and want a more direct way to work from the current source file back to the executable target that owns it.
 
@@ -11,7 +11,7 @@ It is designed for projects that already use `CMakePresets.json` and want a more
 - Resolves preset details from `CMakePresets.json` and `CMakeUserPresets.json`, including `include` and `inherits`
 - Associates configure presets with matching CMake build presets when available
 - Runs preset configure directly from VS Code tasks
-- After the configure is complete, the executable target is automatically discovered
+- After the configure is complete, supported targets are automatically discovered (`EXECUTABLE`, `SHARED_LIBRARY`, `UTILITY`)
 - Builds a source file to executable target mapping from the CMake codemodel
 - Reveals the matching source node when the active editor switches to a mapped file
 - Supports target filtering by target name, executable name, or source file name
@@ -25,7 +25,7 @@ It is designed for projects that already use `CMakePresets.json` and want a more
 The extension revolves around two activity bar views:
 
 - `Presets`: choose the active CMake configure preset
-- `Targets`: inspect discovered executable targets and their source files
+- `Targets`: inspect discovered supported targets and their source files
 
 Typical usage looks like this:
 
@@ -33,7 +33,7 @@ Typical usage looks like this:
 2. Select a configure preset in `Presets`
 3. Run `Build` on that preset to configure the project
 4. The extension reads the CMake File API reply data from the preset's build directory
-5. Discovered executable targets appear in `Targets`
+5. Discovered supported targets appear in `Targets`
 6. Build, run, or debug a target from the tree
 7. When you open a mapped source file, the extension reveals the corresponding source entry in the tree
 
@@ -80,7 +80,7 @@ Open the `cmakerunner` activity bar item and choose a configure preset in the **
 
 Run `Build` on the selected preset. 
 
-If configure succeeds, executable targets appear in **Targets**.
+If configure succeeds, supported targets (`EXECUTABLE`, `SHARED_LIBRARY`, `UTILITY`) appear in **Targets**.
 
 ### 4. Build a target
 
@@ -95,7 +95,7 @@ You can invoke these actions directly on a target:
 - `Run`
 - `Debug`
 
-By default, both actions build the target first.
+By default, both actions build the target first. `Run` and `Debug` only support `EXECUTABLE` targets; non-runnable target types show a warning.
 
 ### 6. Filter targets
 

--- a/doc/README.zh-CN.md
+++ b/doc/README.zh-CN.md
@@ -1,8 +1,8 @@
 # CMake Runner
 
-`CMake Runner` 是一个面向基于 CMake 的 C++ 项目的 VS Code 扩展。它把常见的 **选择 preset -> configure -> 发现可执行目标 -> 构建 -> 运行/调试** 工作流放进一个专用侧边栏中。
+`CMake Runner` 是一个面向基于 CMake 的 C++ 项目的 VS Code 扩展。它把常见的 **选择 preset -> configure -> 发现目标 -> 构建 -> 运行/调试** 工作流放进一个专用侧边栏中。
 
-它适合已经使用 `CMakePresets.json` 管理构建配置，并希望从当前源码文件快速回到所属可执行目标的人群。
+它适合已经使用 `CMakePresets.json` 管理构建配置，并希望从当前源码文件快速回到所属目标的人群。
 
 实现与架构说明见 `architecture.zh-CN.md`。
 
@@ -14,8 +14,8 @@
 - 在存在对应关系时，自动将 configure preset 与 CMake build preset 关联起来
 - 通过 VS Code Task 直接执行 preset configure
 - 在 configure 前自动写入 CMake File API 的 `codemodel-v2` 查询文件
-- 从 `<binaryDir>/.cmake/api/v1/reply/` 发现可执行目标
-- 基于 CMake codemodel 建立“源文件 -> 可执行目标”的映射关系
+- 从 `<binaryDir>/.cmake/api/v1/reply/` 发现受支持目标（`EXECUTABLE`、`SHARED_LIBRARY`、`UTILITY`）
+- 基于 CMake codemodel 建立“源文件 -> 目标”的映射关系
 - 当活动编辑器切换到已映射源码时，在树中定位对应源码节点
 - 支持按目标名、可执行文件名、源码文件名过滤目标
 - 可从 `Targets` 视图或当前已映射源码文件直接执行 build、run、debug
@@ -27,7 +27,7 @@
 插件围绕三个活动栏视图工作：
 
 - `Presets`：选择当前使用的 CMake configure preset
-- `Targets`：查看当前发现的可执行目标及其源码文件
+- `Targets`：查看当前发现的受支持目标及其源码文件
 - `GTests`：按可执行目标查看和运行 GoogleTest 用例
 
 典型流程如下：
@@ -36,7 +36,7 @@
 2. 在 `Presets` 中选择一个 configure preset
 3. 对该 preset 执行 `Build`，先完成 configure
 4. 插件从对应构建目录读取 CMake File API reply 数据
-5. 已发现的可执行目标显示在 `Targets` 中
+5. 已发现的受支持目标显示在 `Targets` 中
 6. 在树上对目标执行 build、run 或 debug
 7. 打开某个已映射源码文件时，插件会在树中定位对应源码节点
 
@@ -88,7 +88,7 @@ code --install-extension cmakerunner-0.x.x.vsix
 <binaryDir>/.cmake/api/v1/reply/
 ```
 
-如果 configure 成功，且 CMake 已生成 File API reply，**Targets** 视图中就会显示该 preset 下识别到的可执行目标。
+如果 configure 成功，且 CMake 已生成 File API reply，**Targets** 视图中就会显示该 preset 下识别到的受支持目标（`EXECUTABLE`、`SHARED_LIBRARY`、`UTILITY`）。
 
 ### 4. 构建目标
 
@@ -103,7 +103,7 @@ code --install-extension cmakerunner-0.x.x.vsix
 - `Run`
 - `Debug`
 
-默认情况下，这两个操作都会先构建目标。
+默认情况下，这两个操作都会先构建目标。`Run` 和 `Debug` 仅支持 `EXECUTABLE` 目标；对不可运行的目标类型会提示 warning。
 
 ### 6. 运行单个 GoogleTest 用例
 

--- a/doc/architecture.zh-CN.md
+++ b/doc/architecture.zh-CN.md
@@ -2,13 +2,13 @@
 
 ## 1. 插件概述
 
-本插件旨在为基于 CMake 的 C++ 项目提供围绕 Preset 和可执行目标的“配置 - 构建 - 运行 - 调试”体验。当前实现主要依赖 `CMakePresets.json` 和 CMake File API 元数据来展示构建预设、识别可执行目标及其源码文件，并提供基于 VS Code 原生 Tasks API 的工作流。
+本插件旨在为基于 CMake 的 C++ 项目提供围绕 Preset 和目标的“配置 - 构建 - 运行 - 调试”体验。当前实现主要依赖 `CMakePresets.json` 和 CMake File API 元数据来展示构建预设、识别受支持目标（`EXECUTABLE`、`SHARED_LIBRARY`、`UTILITY`）及其源码文件，并提供基于 VS Code 原生 Tasks API 的工作流。
 
 ## 2. 核心功能特性
 
 - **智能按需激活**：仅在包含 `CMakePresets.json` 的工作区激活。
 - **预设解析与过滤**：读取 configure presets，并过滤 `hidden: true` 的条目。
-- **源码到目标映射**：基于 CMake File API 返回的 target `sources` 建立 `<源码文件 -> 可执行目标>` 映射。
+- **源码到目标映射**：基于 CMake File API 返回的 target `sources` 建立 `<源码文件 -> 目标>` 映射。
 - **侧边栏视图联动**：通过 TreeView 展示 Preset、Target 与 GTest，并与当前编辑器联动。
 - **原生任务与调试集成**：使用 VS Code Tasks API 执行 configure / build / run，并对接调试能力。
 - **GoogleTest 支持**：通过 `--gtest_list_tests` 发现用例，支持按目标/用例运行与过滤。
@@ -22,7 +22,7 @@
 
 - **TreeView Provider**
   - `Presets` 视图：展示可用 configure preset
-  - `Targets` 视图：展示可执行目标及其源码文件
+  - `Targets` 视图：展示受支持目标及其源码文件
   - `GTests` 视图：展示 GoogleTest 用例并按目标/用例运行
 - **Command Register**
   - 注册 `cmakerunner.buildTarget`、`cmakerunner.debugTarget` 等命令
@@ -34,7 +34,7 @@
 负责数据解析、状态协调与工作流编排。
 
 - **PresetProvider**：解析 `CMakePresets.json`，处理 `inherits`、`displayName`、`binaryDir`，并为 configure preset 关联合适的 build preset / configuration
-- **MappingEngine**：读取 CMake File API codemodel，提取可执行目标、推断可执行文件路径，并建立源码到目标映射
+- **MappingEngine**：读取 CMake File API codemodel，提取受支持目标、推断构建产物路径，并建立源码到目标映射
 - **WorkflowManager**：串联 configure、build、run、debug 生命周期
 
 ### 3.3 执行与集成层
@@ -52,7 +52,7 @@
 3. 用户执行 `Build Preset`
 4. `WorkflowManager` 调用 `TaskExecutionEngine` 运行 configure 命令
 5. configure 成功后，`WorkflowManager` 会先写入 `.cmake/api/v1/query/codemodel-v2` 请求文件，随后 `MappingEngine` 读取构建目录中的 File API reply 数据
-6. `Targets` 视图刷新并显示可执行目标
+6. `Targets` 视图刷新并显示受支持目标
 
 ### 4.2 源码到目标的查询链路
 
@@ -66,7 +66,7 @@
 1. 用户在 `Targets` 视图上选择 `Build`、`Run` 或 `Debug`
 2. 插件根据 target、preset、关联的 build preset / configuration 与配置模板生成实际命令
 3. `TaskExecutionEngine` 以 shell task 方式执行任务；构建任务接入 `$gcc` 和 `$msCompile` problem matcher
-4. `Run` 和 `Debug` 默认都会先构建目标；仅当构建成功后才继续运行或启动调试
+4. `Run` 和 `Debug` 默认都会先构建目标；仅当构建成功后才继续运行或启动调试，且仅 `EXECUTABLE` 目标可运行/调试
 5. `Debug` 由 `WorkflowManager` 动态构造平台默认调试配置并发起调试会话，Windows 默认为 `cppvsdbg`，Linux/macOS 默认为 `lldb`
 
 ## 5. 配置与扩展性设计

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cmakerunner",
     "displayName": "CMake Runner",
     "description": "Preset, target, build, run, and debug workflow for CMake-based C++ projects.",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "publisher": "Simon-tools",
     "repository": {
         "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,6 +122,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
   };
 
+  const getTargetType = (target: TargetInfo): string => target.type ?? 'EXECUTABLE';
+  const isRunnableTarget = (target: TargetInfo): boolean => getTargetType(target) === 'EXECUTABLE';
+
+  const ensureRunnableTarget = (target: TargetInfo, action: string): boolean => {
+    if (isRunnableTarget(target)) {
+      return true;
+    }
+
+    void vscode.window.showWarningMessage(
+      `Target ${target.displayName} is a ${getTargetType(target)} target and cannot be ${action}. Only EXECUTABLE targets are supported for this command.`,
+    );
+    return false;
+  };
+
   const resolveSelectedTarget = (): TargetInfo | undefined => {
     if (!selectedTargetId) {
       return undefined;
@@ -137,8 +151,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     if (selectionChanged && gtestTreeDataProvider.getFilterText()) {
       gtestTreeDataProvider.setFilterText('');
     }
-    const isBuilt = target ? await isTargetBuilt(target) : false;
-    gtestTreeDataProvider.setSelectedTarget(target, isBuilt);
+    const selectedTarget = target && isRunnableTarget(target) ? target : undefined;
+    const isBuilt = selectedTarget ? await isTargetBuilt(selectedTarget) : false;
+    gtestTreeDataProvider.setSelectedTarget(selectedTarget, isBuilt);
     await updateGTestViewState();
   };
 
@@ -752,6 +767,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       await selectTarget(target);
+      if (!ensureRunnableTarget(target, 'run')) {
+        return;
+      }
       await workflowManager.runTarget(preset, target);
       await updateGTestSelection(target);
     }),
@@ -808,6 +826,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       await selectTarget(target);
+      if (!ensureRunnableTarget(target, 'used to run GoogleTest')) {
+        return;
+      }
       await workflowManager.runGTestCase(preset, target, true, undefined, recordGTestRunResult(target));
       await updateGTestSelection(target);
     }),
@@ -833,6 +854,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       await selectTarget(target);
+      if (!ensureRunnableTarget(target, 'debugged')) {
+        return;
+      }
       await workflowManager.debugTarget(preset, target);
       await updateGTestSelection(target);
     }),

--- a/src/models.ts
+++ b/src/models.ts
@@ -12,6 +12,7 @@ export interface TargetInfo {
   readonly id: string;
   readonly name: string;
   readonly displayName: string;
+  readonly type?: string;
   readonly configuration?: string;
   readonly sourceFiles: string[];
   readonly guessedExecutablePath: string;

--- a/src/services/mappingEngine.ts
+++ b/src/services/mappingEngine.ts
@@ -45,6 +45,12 @@ interface FileApiTarget {
   readonly sources?: FileApiTargetSource[];
 }
 
+const SUPPORTED_TARGET_TYPES = new Set([
+  'EXECUTABLE',
+  'SHARED_LIBRARY',
+  'UTILITY',
+]);
+
 export class MappingEngine {
   public constructor(private readonly logger: OutputLogger) {}
 
@@ -128,7 +134,7 @@ export class MappingEngine {
         const targetContent = await vscode.workspace.fs.readFile(targetPath);
         const target = parseJsonBuffer<FileApiTarget>(targetContent).value;
 
-        if (target.type !== 'EXECUTABLE' || !target.name) {
+        if (!target.name || !target.type || !SUPPORTED_TARGET_TYPES.has(target.type)) {
           continue;
         }
 
@@ -152,6 +158,7 @@ export class MappingEngine {
           id: targetKey,
           name: target.name,
           displayName: targetDisplayName,
+          type: target.type,
           configuration: configurationName,
           sourceFiles,
           guessedExecutablePath: executablePath,

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { GTestCaseTreeItem } from '../src/ui/gtestTreeDataProvider';
+import { TargetTreeItem } from '../src/ui/targetTreeDataProvider';
 
 type MockVscode = typeof vscode & {
   __mock: {
@@ -284,6 +285,121 @@ describe('extension commands', () => {
     }
 
     assert.strictEqual(gtestTargetName, 'app');
+  });
+
+  it('runTarget warns and skips workflow for shared-library targets', async () => {
+    await activateExtension();
+
+    const workflowModule = require('../src/services/workflowManager') as typeof import('../src/services/workflowManager');
+    const originalRunTarget = workflowModule.WorkflowManager.prototype.runTarget;
+    const originalShowWarningMessage = vscode.window.showWarningMessage;
+    let warnedMessage = '';
+    let runCalled = false;
+
+    workflowModule.WorkflowManager.prototype.runTarget = async () => {
+      runCalled = true;
+    };
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      warnedMessage = message;
+      return undefined;
+    };
+
+    const libraryTarget = new TargetTreeItem({
+      id: 'mylib',
+      name: 'mylib',
+      displayName: 'mylib',
+      type: 'SHARED_LIBRARY',
+      sourceFiles: [appSourcePath],
+      guessedExecutablePath: path.join(fixtureRoot, 'bin', 'mylib.dll'),
+    });
+
+    try {
+      await vscode.commands.executeCommand('cmakerunner.runTarget', libraryTarget);
+    } finally {
+      workflowModule.WorkflowManager.prototype.runTarget = originalRunTarget;
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
+
+    assert.strictEqual(runCalled, false);
+    assert.ok(warnedMessage.includes('SHARED_LIBRARY'));
+    assert.ok(warnedMessage.includes('cannot be run'));
+  });
+
+  it('debugTarget warns and skips workflow for shared-library targets', async () => {
+    await activateExtension();
+
+    const workflowModule = require('../src/services/workflowManager') as typeof import('../src/services/workflowManager');
+    const originalDebugTarget = workflowModule.WorkflowManager.prototype.debugTarget;
+    const originalShowWarningMessage = vscode.window.showWarningMessage;
+    let warnedMessage = '';
+    let debugCalled = false;
+
+    workflowModule.WorkflowManager.prototype.debugTarget = async () => {
+      debugCalled = true;
+    };
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      warnedMessage = message;
+      return undefined;
+    };
+
+    const libraryTarget = new TargetTreeItem({
+      id: 'mylib',
+      name: 'mylib',
+      displayName: 'mylib',
+      type: 'SHARED_LIBRARY',
+      sourceFiles: [appSourcePath],
+      guessedExecutablePath: path.join(fixtureRoot, 'bin', 'mylib.dll'),
+    });
+
+    try {
+      await vscode.commands.executeCommand('cmakerunner.debugTarget', libraryTarget);
+    } finally {
+      workflowModule.WorkflowManager.prototype.debugTarget = originalDebugTarget;
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
+
+    assert.strictEqual(debugCalled, false);
+    assert.ok(warnedMessage.includes('SHARED_LIBRARY'));
+    assert.ok(warnedMessage.includes('cannot be debugged'));
+  });
+
+  it('runGTestCase warns and skips workflow for shared-library targets', async () => {
+    await activateExtension();
+
+    const workflowModule = require('../src/services/workflowManager') as typeof import('../src/services/workflowManager');
+    const originalRunGTestCase = workflowModule.WorkflowManager.prototype.runGTestCase;
+    const originalShowWarningMessage = vscode.window.showWarningMessage;
+    let warnedMessage = '';
+    let runCalled = false;
+
+    workflowModule.WorkflowManager.prototype.runGTestCase = async () => {
+      runCalled = true;
+      return undefined;
+    };
+    (vscode.window as any).showWarningMessage = async (message: string) => {
+      warnedMessage = message;
+      return undefined;
+    };
+
+    const libraryTarget = new TargetTreeItem({
+      id: 'mylib',
+      name: 'mylib',
+      displayName: 'mylib',
+      type: 'SHARED_LIBRARY',
+      sourceFiles: [appSourcePath],
+      guessedExecutablePath: path.join(fixtureRoot, 'bin', 'mylib.dll'),
+    });
+
+    try {
+      await vscode.commands.executeCommand('cmakerunner.runGTestCase', libraryTarget);
+    } finally {
+      workflowModule.WorkflowManager.prototype.runGTestCase = originalRunGTestCase;
+      (vscode.window as any).showWarningMessage = originalShowWarningMessage;
+    }
+
+    assert.strictEqual(runCalled, false);
+    assert.ok(warnedMessage.includes('SHARED_LIBRARY'));
+    assert.ok(warnedMessage.includes('used to run GoogleTest'));
   });
 
   it('openGTestCaseSource opens the matching source file', async () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -113,6 +113,7 @@ describe('integration', () => {
             targets: [
               { name: 'app', id: 'app', jsonFile: 'target-app.json' },
               { name: 'helper', id: 'helper', jsonFile: 'target-helper.json' },
+              { name: 'install', id: 'install', jsonFile: 'target-install.json' },
             ],
           },
         ],
@@ -136,6 +137,13 @@ describe('integration', () => {
         name: 'helper',
         type: 'STATIC_LIBRARY',
         sources: [{ path: path.join(mappingWorkspaceDir, 'src', 'helper.cpp') }],
+      }, null, 2),
+    );
+    fs.writeFileSync(
+      path.join(replyDir, 'target-install.json'),
+      JSON.stringify({
+        name: 'install',
+        type: 'UTILITY',
       }, null, 2),
     );
 
@@ -259,7 +267,7 @@ describe('integration', () => {
       assert.strictEqual(targets.length, 0);
     });
 
-    it('should build executable target index from file api reply', async () => {
+    it('should build executable/shared-library/utility target index from file api reply', async () => {
       const engine = new MappingEngine(logger);
       await engine.rebuild({
         name: 'debug',
@@ -268,11 +276,12 @@ describe('integration', () => {
         sourceDir: mappingWorkspaceDir,
       });
       const targets = engine.getTargets();
-      assert.strictEqual(targets.length, 1);
-      assert.strictEqual(targets[0].name, 'app');
+      assert.strictEqual(targets.length, 2);
+      assert.deepStrictEqual(targets.map((target) => target.name), ['app', 'install']);
       assert.strictEqual(targets[0].configuration, 'Debug');
       assert.strictEqual(targets[0].sourceFiles.length, 1);
       assert.ok(targets[0].guessedExecutablePath.includes('bin'));
+      assert.strictEqual(targets[1].type, 'UTILITY');
     });
 
     it('should find target by normalized source path after rebuild', async () => {


### PR DESCRIPTION
### Motivation

- Include additional CMake target types discovered via the File API so source->target mapping reflects real project targets and avoid attempting to run/debug non-executable artifacts.
- Make run/debug/GTest actions safe by restricting execution to runnable targets and surfacing a clear warning when a user tries to run or debug a non-executable target.

### Description

- Add optional `type` to `TargetInfo` and populate it from the CMake File API codemodel so targets carry their CMake `type`.
- Extend `MappingEngine` to accept and index supported target types `EXECUTABLE`, `SHARED_LIBRARY`, and `UTILITY` (via `SUPPORTED_TARGET_TYPES`) when building the mapping from File API reply.
- Add runtime guards in `extension.ts`: `getTargetType`, `isRunnableTarget`, and `ensureRunnableTarget`, and use them to show a warning and skip `runTarget`, `debugTarget`, and `runGTestCase` for non-`EXECUTABLE` targets.
- Update documentation and changelog files (`README.md`, `README-ALL.md`, `doc/*`, `CHANGELOG.md`) to document supported target types and that `Run`/`Debug` only apply to `EXECUTABLE` targets, and bump package version to `0.3.4` in `package.json`.

### Testing

- Ran the automated test suite including `test/extension.test.ts` and `test/integration.test.ts` (via `npm test`); all tests passed.
- Added unit tests in `test/extension.test.ts` to assert that `runTarget`, `debugTarget`, and `runGTestCase` warn and do not invoke workflow for `SHARED_LIBRARY` targets, and they succeeded.
- Updated integration tests to include a `UTILITY` target in the File API reply and verified `MappingEngine` indexes the new supported target types successfully.